### PR TITLE
Improve card responsiveness

### DIFF
--- a/frontend/src/pages/AdminActions.js
+++ b/frontend/src/pages/AdminActions.js
@@ -654,7 +654,7 @@ const AdminActions = () => {
 
                 {selectedCardDetails && (
                     <div className="card-availability-editor" style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', marginTop: '1rem' }}>
-                        <div style={{ flex: '1 1 300px', minWidth: '300px' }}>
+                        <div style={{ flex: '1 1 45%', minWidth: '250px' }}>
                             <h3>{selectedCardDetails.name}</h3>
                             <label>Available From:</label>
                             <input
@@ -699,7 +699,7 @@ const AdminActions = () => {
                                 {loading ? 'Saving...' : 'Save Availability'}
                             </button>
                         </div>
-                        <div style={{ flex: '1 1 300px', minWidth: '300px' }}>
+                        <div style={{ flex: '1 1 45%', minWidth: '250px' }}>
                             <h3>Card Preview</h3>
                             <BaseCard
                                 name={selectedCardDetails.name}

--- a/frontend/src/styles/AdminDashboardPage.css
+++ b/frontend/src/styles/AdminDashboardPage.css
@@ -288,8 +288,9 @@
 
 /* card-content forced 300x450 */
 .card-content {
-    width: 300px;
-    height: 450px;
+    width: 100%;
+    max-width: 300px;
+    aspect-ratio: 2 / 3;
     position: relative;
     perspective: 1000px;
     border: none !important;
@@ -470,4 +471,10 @@
 
 .suggestions-list li:hover {
   background: var(--surface-darker);
+}
+
+@media (max-width: 600px) {
+  .card-content {
+    max-width: 200px;
+  }
 }

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -2,8 +2,9 @@
  * Generic Card Styles (Layout Only)
  **************************************/
 .card-container {
-    width: 300px;
-    height: 450px;
+    width: 100%;
+    max-width: 300px;
+    aspect-ratio: 2 / 3;
     border-radius: 15px;
     overflow: hidden;
     display: flex;
@@ -84,7 +85,7 @@
     justify-content: center;
     margin: 5px 0;
     margin-top: -10px;
-    height: 220px;
+    height: 48%;
     overflow: hidden;
     border-radius: 10px;
     border: 6px solid #6f4e37;
@@ -122,7 +123,7 @@
 .card-description {
     font-size: 0.9rem;
     margin: 8px 10px;
-    height: 90px;
+    max-height: 20%;
     overflow: hidden;
     text-overflow: ellipsis;
     padding: 5px;
@@ -670,6 +671,15 @@
         -webkit-text-stroke: 1px white;
         text-shadow: 1px 1px 5px black;
     }
+
+@media (max-width: 600px) {
+    .card-container {
+        max-width: 200px;
+    }
+    .card-artwork {
+        height: 50%;
+    }
+}
 
 /**************************************
  * End of File

--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -115,7 +115,7 @@
 /* Grid layout for catalogue cards */
 .catalogue-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 30px;
     margin-bottom: 40px;
 }
@@ -128,7 +128,8 @@
 
 .card-inner {
     position: relative;
-    width: 300px; /* Match this to your card's intended width */
+    width: 100%;
+    max-width: 300px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -158,4 +159,10 @@
 .timeleft-badge {
     top: 10px;
     left: 10px;
+}
+
+@media (max-width: 600px) {
+    .catalogue-grid {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
 }

--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -46,7 +46,7 @@ body {
 /* Grid Layout for Dashboard Sections */
 .dashboard-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 2rem;
     max-width: 1400px;
     margin: 0 auto;
@@ -131,4 +131,10 @@ body {
     text-align: center;
     font-size: 1.5rem;
     margin-top: 2rem;
+}
+
+@media (max-width: 600px) {
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
## Summary
- make BaseCard width and height responsive
- allow catalogue and dashboard card grids to adapt on small screens
- shrink Admin dashboard card preview when viewport is small
- adjust Admin action inline styles for card preview panels

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfcd018083309443813d80ad8ba7