### PR TITLE
Make catalogue responsive

### DIFF
--- a/frontend/src/pages/CataloguePage.js
+++ b/frontend/src/pages/CataloguePage.js
@@ -105,26 +105,26 @@ const CataloguePage = () => {
     });
 
     if (loading) return <LoadingSpinner />;
-    if (error) return <div className="catalogue-page">{error}</div>;
+    if (error) return <div className="cata-page">{error}</div>;
 
     const RemainingBadge = ({ remaining }) =>
         remaining !== null && remaining !== undefined ? (
-            <div className="card-overlay-badge remaining-badge">
+            <div className="cata-overlay-badge cata-remaining-badge">
                 {remaining} remaining
             </div>
         ) : null;
 
     return (
-        <div className="catalogue-page">
+        <div className="cata-page">
             <h1>Card Catalogue</h1>
-            <p className="catalogue-description">
+            <p className="cata-description">
                 Explore our complete collection of trading cards. Use the search box to
                 find cards by name, and click on the rarity buttons below to preview each
                 card in a different style.
             </p>
 
-            <div className="filters-container">
-                <div className="search-box">
+            <div className="cata-filters-container">
+                <div className="cata-search-box">
                     <input
                         type="text"
                         value={searchQuery}
@@ -132,14 +132,14 @@ const CataloguePage = () => {
                         placeholder="Search cards..."
                     />
                 </div>
-                <div className="rarity-selector">
+                <div className="cata-rarity-selector">
                     {rarityData.map((r) => {
                         const textColor = r.name === 'Divine' ? '#000' : '#fff';
                         return (
                             <button
                                 key={r.name}
                                 onClick={() => handleRarityChange(r.name)}
-                                className={`rarity-button ${selectedRarity === r.name ? 'active' : ''}`}
+                                className={`cata-rarity-button ${selectedRarity === r.name ? 'active' : ''}`}
                                 style={{
                                     backgroundColor: r.color,
                                     color: textColor,
@@ -152,7 +152,7 @@ const CataloguePage = () => {
                         );
                     })}
                 </div>
-                <div className="sort-box">
+                <div className="cata-sort-box">
                     <label htmlFor="sortField">Sort by:</label>
                     <select id="sortField" value={sortOption} onChange={handleSortChange}>
                         <option value="name">Name</option>
@@ -166,7 +166,7 @@ const CataloguePage = () => {
 
             {/* Limited Time Cards */}
             <h2>Limited Time Cards</h2>
-            <div className="catalogue-grid">
+            <div className="cata-grid">
                 {activeLimitedCards.length > 0 ? (
                     activeLimitedCards.map((card) => {
                         const to = card.availableTo ? new Date(card.availableTo) : null;
@@ -178,8 +178,8 @@ const CataloguePage = () => {
                         const remaining = getRemaining(card.name, selectedRarity);
 
                         return (
-                            <div key={card._id} className="catalogue-card">
-                                <div className="card-inner">
+                            <div key={card._id} className="cata-card">
+                                <div className="cata-card-inner">
                                     <BaseCard
                                         name={card.name}
                                         image={card.imageUrl}
@@ -189,7 +189,7 @@ const CataloguePage = () => {
                                     />
                                     <RemainingBadge remaining={remaining} />
                                     {to && timeLeft > 0 && (
-                                        <div className="card-overlay-badge timeleft-badge">
+                                        <div className="cata-overlay-badge cata-timeleft-badge">
                                             Ends in: {days}d {hours}h {minutes}m {seconds}s
                                         </div>
                                     )}
@@ -204,7 +204,7 @@ const CataloguePage = () => {
 
             {/* All Limited Cards */}
             <h2>All Limited Cards (Past, Present, Future)</h2>
-            <div className="catalogue-grid">
+            <div className="cata-grid">
                 {limitedCards.length > 0 ? (
                     limitedCards.map((card) => {
                         const from = card.availableFrom ? new Date(card.availableFrom) : null;
@@ -217,8 +217,8 @@ const CataloguePage = () => {
                         const remaining = getRemaining(card.name, selectedRarity);
 
                         return (
-                            <div key={card._id} className="catalogue-card">
-                                <div className="card-inner">
+                            <div key={card._id} className="cata-card">
+                                <div className="cata-card-inner">
                                     <BaseCard
                                         name={card.name}
                                         image={card.imageUrl}
@@ -227,7 +227,7 @@ const CataloguePage = () => {
                                         mintNumber={card.mintNumber}
                                     />
                                     <RemainingBadge remaining={remaining} />
-                                    <div className="card-overlay-badge timeleft-badge">
+                                    <div className="cata-overlay-badge cata-timeleft-badge">
                                         {status}
                                     </div>
                                 </div>
@@ -241,14 +241,14 @@ const CataloguePage = () => {
 
             {/* All Cards */}
             <h2>All Cards</h2>
-            <div className="catalogue-grid">
+            <div className="cata-grid">
                 {sortedCards.length > 0 ? (
                     sortedCards.map((card) => {
                         const remaining = getRemaining(card.name, selectedRarity);
 
                         return (
-                            <div key={card._id} className="catalogue-card">
-                                <div className="card-inner">
+                            <div key={card._id} className="cata-card">
+                                <div className="cata-card-inner">
                                     <BaseCard
                                         name={card.name}
                                         image={card.imageUrl}

--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -1,5 +1,5 @@
 /* Overall page container */
-.catalogue-page {
+.cata-page {
     padding: 40px 20px;
     max-width: 1800px;
     margin: 0 auto;
@@ -8,7 +8,7 @@
     min-height: 100vh;
 }
 
-.catalogue-page h1 {
+.cata-page h1 {
     text-align: center;
     margin-top: 100px;
     margin-bottom: 10px;
@@ -17,7 +17,7 @@
     letter-spacing: 1px;
 }
 
-.catalogue-description {
+.cata-description {
     text-align: center;
     font-size: 1.2rem;
     margin-bottom: 30px;
@@ -25,7 +25,7 @@
 }
 
 /* Container for filters arranged in a column */
-.filters-container {
+.cata-filters-container {
     display: flex;
     flex-direction: column;
     gap: 20px;
@@ -35,13 +35,13 @@
 }
 
 /* Search box styling */
-.search-box {
+.cata-search-box {
     width: 100%;
     display: flex;
     justify-content: center;
 }
 
-.search-box input {
+.cata-search-box input {
     padding: 12px 16px;
     width: 100%;
     max-width: 500px;
@@ -54,13 +54,13 @@
     transition: box-shadow 0.3s ease;
 }
 
-.search-box input:focus {
+.cata-search-box input:focus {
     outline: none;
     box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.3);
 }
 
 /* Rarity selector buttons */
-.rarity-selector {
+.cata-rarity-selector {
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
@@ -68,35 +68,35 @@
     margin-top: 10px;
 }
 
-.rarity-button {
+.cata-rarity-button {
     border-radius: 6px;
     cursor: pointer;
     transition: background-color 0.3s ease, transform 0.2s ease;
     font-size: 1rem;
 }
 
-.rarity-button:hover {
+.cata-rarity-button:hover {
     transform: scale(1.05);
     opacity: 0.9;
 }
 
-.rarity-button.active {
+.cata-rarity-button.active {
     box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
 }
 
 /* Sort box styling */
-.sort-box {
+.cata-sort-box {
     display: flex;
     align-items: center;
     gap: 10px;
 }
 
-.sort-box label {
+.cata-sort-box label {
     font-size: 1rem;
     color: #f5f5dc;
 }
 
-.sort-box select {
+.cata-sort-box select {
     padding: 10px;
     border: none;
     border-radius: 6px;
@@ -107,26 +107,26 @@
     transition: box-shadow 0.3s ease;
 }
 
-.sort-box select:focus {
+.cata-sort-box select:focus {
     outline: none;
     box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.3);
 }
 
 /* Grid layout for catalogue cards */
-.catalogue-grid {
+.cata-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 30px;
     margin-bottom: 40px;
 }
 
-.catalogue-card {
+.cata-card {
     display: flex;
     justify-content: center;
     position: relative;
 }
 
-.card-inner {
+.cata-card-inner {
     position: relative;
     width: 100%;
     max-width: 300px;
@@ -136,7 +136,7 @@
 }
 
 /* Shared overlay badge style for all overlays */
-.card-overlay-badge {
+.cata-overlay-badge {
     position: absolute;
     background: rgba(0, 0, 0, 0.541);
     color: #d4d0c0;
@@ -151,18 +151,21 @@
 }
 
 /* Specific positions for each badge */
-.remaining-badge {
+.cata-remaining-badge {
     bottom: 10px;
     right: 10px;
 }
 
-.timeleft-badge {
+.cata-timeleft-badge {
     top: 10px;
     left: 10px;
 }
 
 @media (max-width: 600px) {
-    .catalogue-grid {
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    .cata-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .cata-card-inner .card-container {
+        width: 100%;
     }
 }


### PR DESCRIPTION
## Summary
- make catalogue grid responsive for mobile
- namespace catalogue page classes with `cata-` prefix

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68416c946bd48330916fc0430c23a9f3