### PR TITLE
Fix mobile card scaling

### DIFF
--- a/frontend/src/styles/AdminDashboardPage.css
+++ b/frontend/src/styles/AdminDashboardPage.css
@@ -288,13 +288,16 @@
 
 /* card-content forced 300x450 */
 .card-content {
-    width: 100%;
+    --card-scale: 1;
+    width: calc(100% / var(--card-scale));
     max-width: 300px;
     aspect-ratio: 2 / 3;
     position: relative;
     perspective: 1000px;
     border: none !important;
     overflow: visible !important;
+    transform: scale(var(--card-scale));
+    transform-origin: top left;
 }
 
 /* 3D flipping container */
@@ -475,6 +478,6 @@
 
 @media (max-width: 600px) {
   .card-content {
-    max-width: 200px;
+    --card-scale: 0.67;
   }
 }

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -672,14 +672,6 @@
         text-shadow: 1px 1px 5px black;
     }
 
-@media (max-width: 600px) {
-    .card-container {
-        max-width: 200px;
-    }
-    .card-artwork {
-        height: 50%;
-    }
-}
 
 /**************************************
  * End of File

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -115,6 +115,7 @@
 
 /* User Collection Grid */
 .market-user-collection-grid {
+    --listing-card-scale: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -122,6 +123,9 @@
     max-height: 800px;
     overflow-y: auto;
     padding-right: 0.5rem;
+    width: calc(100% / var(--listing-card-scale));
+    transform: scale(var(--listing-card-scale));
+    transform-origin: top left;
 }
 
     .market-user-collection-grid .market-card-wrapper {
@@ -148,6 +152,7 @@
     }
 
 .market-selected-cards-grid {
+    --listing-card-scale: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -155,6 +160,9 @@
     max-height: 800px; /* Increased height for selected cards panel */
     overflow-y: auto;
     padding-right: 0.5rem;
+    width: calc(100% / var(--listing-card-scale));
+    transform: scale(var(--listing-card-scale));
+    transform-origin: top left;
 }
 
 /* Offers list styling */
@@ -211,10 +219,14 @@
 }
 
 .offered-cards-grid {
+    --listing-card-scale: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
     margin-top: 0.5rem;
+    width: calc(100% / var(--listing-card-scale));
+    transform: scale(var(--listing-card-scale));
+    transform-origin: top left;
 }
 
 .offered-card-item {
@@ -229,11 +241,8 @@
 
 @media (max-width: 600px) {
     .market-user-collection-grid,
-    .market-selected-cards-grid {
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    }
-    .offered-card-item {
-        max-width: 200px;
-        flex-basis: 200px;
+    .market-selected-cards-grid,
+    .offered-cards-grid {
+        --listing-card-scale: 0.8;
     }
 }

--- a/frontend/src/styles/MarketPage.css
+++ b/frontend/src/styles/MarketPage.css
@@ -78,10 +78,14 @@
     }
 
 .listings-grid {
+    --listing-card-scale: 1;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 2rem;
     margin-bottom: 3rem;
+    width: calc(100% / var(--listing-card-scale));
+    transform: scale(var(--listing-card-scale));
+    transform-origin: top left;
 }
 
 .listing-card {
@@ -164,10 +168,6 @@
 
 @media (max-width: 600px) {
     .listings-grid {
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    }
-    .listing-card {
-        max-width: 200px;
-        flex-basis: 200px;
+        --listing-card-scale: 0.71;
     }
 }

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -248,14 +248,17 @@
 
 /* Card Preview Wrapper (for other sections) */
 .tp-card-preview-wrapper {
+    --tp-card-scale: 1;
     flex: 0 0 45%;
-    width: 100%;
+    width: calc(100% / var(--tp-card-scale));
     max-width: 280px;
     aspect-ratio: 2 / 3;
     position: relative;
     transition: var(--transition);
     border-radius: var(--border-radius);
     background: var(--surface-dark);
+    transform: scale(var(--tp-card-scale));
+    transform-origin: top left;
 }
 
     .tp-card-preview-wrapper:hover {
@@ -420,6 +423,6 @@
 
 @media (max-width: 600px) {
     .tp-card-preview-wrapper {
-        max-width: 200px;
+        --tp-card-scale: 0.71;
     }
 }


### PR DESCRIPTION
## Summary
- remove old responsive rules that shrank cards
- scale cards uniformly using CSS variables on market, listing details, trading and admin dashboards
- clean up BaseCard styles

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(prints 'Error: no test specified')*

------
https://chatgpt.com/codex/tasks/task_e_6841bc14f5088330a47a6621090f3e87