### PR TITLE
Update navbar behavior and dropdown

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -72,7 +72,7 @@ const Navbar = ({ isAdmin }) => {
                 <span className="burger-bar"></span>
             </button>
 
-            <div className="navbar-logo">
+            <div className="navbar-logo" onClick={() => navigate('/dashboard')} style={{cursor: 'pointer'}}>
                 <img src="/images/NedsDecksLogo.png" alt="Ned's Decks" />
             </div>
 
@@ -111,29 +111,11 @@ const Navbar = ({ isAdmin }) => {
             >
                 <li>
                     <NavLink
-                        to="/dashboard"
-                        className="nav-link"
-                        onClick={() => setMenuOpen(false)}
-                    >
-                        Dashboard
-                    </NavLink>
-                </li>
-                <li>
-                    <NavLink
                         to={`/collection/${loggedInUser.username}`}
                         className="nav-link"
                         onClick={() => setMenuOpen(false)}
                     >
                         Collection
-                    </NavLink>
-                </li>
-                <li>
-                    <NavLink
-                        to={`/profile/${loggedInUser.username}`}
-                        className="nav-link"
-                        onClick={() => setMenuOpen(false)}
-                    >
-                        My Profile
                     </NavLink>
                 </li>
                 <li>
@@ -185,25 +167,17 @@ const Navbar = ({ isAdmin }) => {
                         Catalogue
                     </NavLink>
                 </li>
-                <li>
-                    <button
-                        className="logout-button"
-                        onClick={() => {
-                            setMenuOpen(false);
-                            handleLogout();
-                        }}
-                    >
-                        Logout
-                    </button>
-                </li>
             </ul>
 
             {/* Render NotificationDropdown only when loggedInUser._id is available */}
             {loggedInUser._id && (
                 <div className="navbar-notifications">
+                    <span className="navbar-username">{loggedInUser.username}</span>
                     <NotificationDropdown
                         profilePic={loggedInUser.twitchProfilePic || '/images/defaultProfile.png'}
                         userId={loggedInUser._id}
+                        username={loggedInUser.username}
+                        onLogout={handleLogout}
                     />
                 </div>
             )}

--- a/frontend/src/components/NotificationDropdown.js
+++ b/frontend/src/components/NotificationDropdown.js
@@ -5,7 +5,7 @@ import '../styles/NotificationDropdown.css';
 import { fetchWithAuth, API_BASE_URL } from '../utils/api';
 import io from 'socket.io-client';
 
-const NotificationDropdown = ({ profilePic, userId }) => {
+const NotificationDropdown = ({ profilePic, userId, username, onLogout }) => {
     const [notifications, setNotifications] = useState([]);
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef(null);
@@ -114,6 +114,11 @@ const NotificationDropdown = ({ profilePic, userId }) => {
             </button>
             {isOpen && (
                 <div className="notification-menu">
+                    <div className="profile-actions">
+                        <Link to={`/profile/${username}`} onClick={() => setIsOpen(false)} className="profile-action">My Profile</Link>
+                        <button className="profile-action" onClick={() => { onLogout(); setIsOpen(false); }}>Logout</button>
+                    </div>
+                    <hr className="profile-divider" />
                     {notifications.length > 0 ? (
                         <>
                             <ul>

--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -137,16 +137,6 @@
         color: var(--brand-secondary);
     }
 
-/* Logout Button */
-.logout-button {
-    background: none;
-    border: none;
-    color: var(--text-primary);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: color 0.3s ease, transform 0.3s ease;
-}
-
 /* Burger Button */
 .burger-button {
     display: none;
@@ -166,10 +156,6 @@
     background: var(--text-primary);
 }
 
-    .logout-button:hover {
-        color: var(--brand-secondary);
-        transform: scale(1.1);
-    }
 
 /* New logo image styling */
 .navbar-logo img {
@@ -182,6 +168,14 @@
 /* Add this rule or update your existing .navbar-notifications */
 .navbar-notifications {
     margin-left: 20px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.navbar-username {
+    color: var(--text-primary);
+    font-weight: 500;
 }
 
 

--- a/frontend/src/styles/NotificationDropdown.css
+++ b/frontend/src/styles/NotificationDropdown.css
@@ -47,6 +47,32 @@
     z-index: 1000;
 }
 
+/* Profile actions at top of dropdown */
+.profile-actions {
+    display: flex;
+    flex-direction: column;
+}
+
+.profile-action {
+    padding: 0.75rem 1rem;
+    background: none;
+    border: none;
+    text-align: left;
+    color: var(--text-primary);
+    cursor: pointer;
+    width: 100%;
+}
+
+.profile-action:hover {
+    background: var(--surface-darker);
+}
+
+.profile-divider {
+    border: none;
+    border-top: 1px solid var(--border-dark);
+    margin: 0;
+}
+
 .notification-item {
     padding: 1rem;
     border-bottom: 1px solid var(--border-dark);


### PR DESCRIPTION
## Summary
- make logo navigate home
- show logged-in username next to profile picture
- drop dashboard, logout, and profile links from navbar
- move profile/logout actions to notification dropdown

## Testing
- `npm install` *(for frontend)*
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6841c697a45c83309491328333906a06