### PR TITLE
Add pack type dropdown & 30 min user filter

### DIFF
--- a/frontend/src/styles/AdminDashboardPage.css
+++ b/frontend/src/styles/AdminDashboardPage.css
@@ -134,6 +134,16 @@
     max-height: 320px;
 }
 
+.pack-type-select {
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    background: var(--surface-darker);
+    color: var(--text-primary);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--border-radius);
+    font-size: 1rem;
+}
+
     .selected-user-section h2 {
         font-size: 1.5rem;
         color: var(--text-primary);


### PR DESCRIPTION
## Summary
- extend activity filter to last 30 minutes
- allow admins to choose pack type when opening packs
- fetch pack templates on admin dashboard
- add styles for new pack-type selector

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841d01944c483309358ebc41ee090d3