### PR TITLE
Improve trade performance and user feedback

### DIFF
--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -332,7 +332,8 @@ const getPendingTrades = async (req, res) => {
             status: 'pending'
         })
             .populate('sender', 'username cards')
-            .populate('recipient', 'username cards');
+            .populate('recipient', 'username cards')
+            .lean();
 
         const enrichedTrades = pendingTrades.map(trade => {
             const senderData = trade.sender || { cards: [] };
@@ -367,7 +368,8 @@ const getTradesForUser = async (req, res) => {
             $or: [{ sender: userId }, { recipient: userId }]
         })
             .populate('sender', 'username cards')
-            .populate('recipient', 'username cards');
+            .populate('recipient', 'username cards')
+            .lean();
 
         const enrichedTrades = trades.map(trade => {
             const senderData = trade.sender || { cards: [] };

--- a/backend/src/models/MarketListing.js
+++ b/backend/src/models/MarketListing.js
@@ -34,4 +34,7 @@ const marketListingSchema = new mongoose.Schema({
   offers: [offerSchema]
 });
 
+// Index status for faster retrieval of active listings
+marketListingSchema.index({ status: 1 });
+
 module.exports = mongoose.model('MarketListing', marketListingSchema);

--- a/backend/src/models/tradeModel.js
+++ b/backend/src/models/tradeModel.js
@@ -18,5 +18,10 @@ const tradeSchema = new mongoose.Schema({
   timestamps: true
 });
 
+// Index commonly queried fields for faster lookups
+tradeSchema.index({ status: 1 });
+tradeSchema.index({ sender: 1 });
+tradeSchema.index({ recipient: 1 });
+
 const Trade = mongoose.model('Trade', tradeSchema);
 module.exports = Trade;

--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -121,6 +121,7 @@ const MarketListingDetails = () => {
                 }),
             });
             if (res.message === 'Offer submitted successfully') {
+                window.showToast('Offer submitted successfully!', 'success');
                 setOfferSuccess('Offer submitted successfully!');
                 setOfferMessage('');
                 setOfferedPacks('');


### PR DESCRIPTION
## Summary
- add mongo indexes for trades and market listings
- use lean queries for user trade lookups
- toast notification when market offer is submitted

## Testing
- `npm test` within `backend` *(fails: no test specified)*
- `npm test --silent` within `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684208ca220c8330b1d69fb904ce20ee