### PR TITLE
Fix fetching pending trades

### DIFF
--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -347,7 +347,7 @@ const getPendingTrades = async (req, res) => {
             );
 
             return {
-                ...trade.toObject(),
+                ...trade,
                 offeredItems: offeredCards,
                 requestedItems: requestedCards
             };
@@ -383,7 +383,7 @@ const getTradesForUser = async (req, res) => {
             );
 
             return {
-                ...trade.toObject(),
+                ...trade,
                 offeredItems: offeredCards,
                 requestedItems: requestedCards
             };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -204,9 +204,10 @@ export const fetchTrades = async (userId) => {
 };
 
 // Fetch pending trades with status filtering
-export const fetchPendingTrades = async (userId, status = 'Pending') => {
+// Fetch pending trades for a user
+export const fetchPendingTrades = async (userId) => {
     try {
-        const response = await fetchWithAuth(`/api/trades/${userId}?status=${status}`);
+        const response = await fetchWithAuth(`/api/trades/${userId}/pending`);
         console.log("[API] Fetched Pending Trades:", response);
         return response;
     } catch (error) {


### PR DESCRIPTION
## Summary
- return lean trade docs directly instead of calling `.toObject()`
- use dedicated `/pending` endpoint for fetching pending trades

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68420d40ca888330a7b95d4538e1d992