### PR TITLE
Improve navbar responsiveness

### DIFF
--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -46,7 +46,7 @@
 
 .search-wrapper {
     position: relative;
-    width: clamp(200px, 40vw, 600px);
+    width: clamp(180px, 35vw, 500px);
 }
 
 .search-bar {
@@ -111,7 +111,7 @@
     margin: 0;
     padding: 0;
     gap: 1rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
     .navbar-links li {
@@ -180,7 +180,7 @@
 
 
 /* Responsive Adjustments */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     .burger-button {
         display: flex;
         order: -1;
@@ -216,11 +216,15 @@
     }
 
     .search-wrapper {
-        width: 100%;
+        width: clamp(180px, 50vw, 400px);
     }
 
     .navbar-logo h1 {
         font-size: 1.5rem;
+    }
+
+    .navbar-username {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- tune navbar search width
- prevent navbar links wrapping
- show burger menu up to 1024px screen width and hide username in that range

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test` *(fails: react-scripts not found)*
- `cd ../backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68436b9cae648330bd74c4b722df4939