### PR TITLE
Add counter offer to trades UI

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -1,5 +1,6 @@
 // src/pages/PendingTrades.js
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { fetchUserProfile, fetchPendingTrades, acceptTrade, rejectTrade, cancelTrade } from '../utils/api';
 import BaseCard from '../components/BaseCard';
 import LoadingSpinner from '../components/LoadingSpinner'; // Import the spinner
@@ -14,6 +15,7 @@ const PendingTrades = () => {
     const [filter, setFilter] = useState('all');
     const [sortOrder, setSortOrder] = useState('newest');
     const [expandedTrades, setExpandedTrades] = useState({});
+    const navigate = useNavigate();
 
     useEffect(() => {
         const loadUserProfile = async () => {
@@ -58,6 +60,21 @@ const PendingTrades = () => {
                 setError(`Failed to ${action} trade`);
             }
         }
+    };
+
+    const handleCounterOffer = (trade, e) => {
+        e.stopPropagation();
+        navigate('/trading', {
+            state: {
+                counterOffer: {
+                    selectedUser: trade.sender.username,
+                    tradeOffer: trade.requestedItems,
+                    tradeRequest: trade.offeredItems,
+                    offeredPacks: trade.requestedPacks,
+                    requestedPacks: trade.offeredPacks,
+                },
+            },
+        });
     };
 
     const handleSearch = (e) => setSearchQuery(e.target.value.toLowerCase());
@@ -119,7 +136,8 @@ const PendingTrades = () => {
             {filteredAndSortedTrades.length === 0 ? (
                 <p className="no-trades">No pending trades.</p>
             ) : (
-                filteredAndSortedTrades.map((trade) => {
+                <div className="trades-grid">
+                {filteredAndSortedTrades.map((trade) => {
                     const isOutgoing = trade.sender._id === loggedInUser._id;
                     const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'}`;
                     const isExpanded = expandedTrades[trade._id];
@@ -152,6 +170,12 @@ const PendingTrades = () => {
                                                     onClick={(e) => handleTradeAction(trade._id, 'reject', e)}
                                                 >
                                                     Reject
+                                                </button>
+                                                <button
+                                                    className="counter-button"
+                                                    onClick={(e) => handleCounterOffer(trade, e)}
+                                                >
+                                                    Counter
                                                 </button>
                                             </>
                                         ) : (
@@ -219,7 +243,8 @@ const PendingTrades = () => {
                             </div>
                         </div>
                     );
-                })
+                })}
+                </div>
             )}
         </div>
     );

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { createTrade, searchUsers, fetchWithAuth } from "../utils/api";
 import BaseCard from "../components/BaseCard";
 import "../styles/TradingPage.css";
 import { rarities } from "../constants/rarities";
 
 const TradingPage = ({ userId }) => {
+    const location = useLocation();
     const [showTradeForm, setShowTradeForm] = useState(false);
     const [searchQuery, setSearchQuery] = useState("");
     const [userSuggestions, setUserSuggestions] = useState([]);
@@ -36,6 +37,19 @@ const TradingPage = ({ userId }) => {
             })
             .catch(console.error);
     }, []);
+
+    // If navigated with counter offer data, pre-populate the trade form
+    useEffect(() => {
+        const counter = location.state?.counterOffer;
+        if (counter) {
+            setShowTradeForm(true);
+            setSelectedUser(counter.selectedUser);
+            setTradeOffer(counter.tradeOffer || []);
+            setTradeRequest(counter.tradeRequest || []);
+            setOfferedPacks(counter.offeredPacks || 0);
+            setRequestedPacks(counter.requestedPacks || 0);
+        }
+    }, [location.state]);
 
     // Fetch user search suggestions
     useEffect(() => {

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -52,6 +52,13 @@
     justify-content: center;
 }
 
+/* Grid layout for trade tiles */
+.trades-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
     .filters input,
     .filters select {
         padding: 0.75rem 1rem;
@@ -126,10 +133,26 @@
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     }
 
-        .trade-buttons-inline button:hover {
-            background-color: #722ebf;
-            transform: scale(1.05);
-        }
+    .trade-buttons-inline button:hover {
+        background-color: #722ebf;
+        transform: scale(1.05);
+    }
+
+.accept-button {
+    background-color: #2e7d32;
+}
+
+.reject-button {
+    background-color: #c62828;
+}
+
+.cancel-button {
+    background-color: #616161;
+}
+
+.counter-button {
+    background-color: var(--brand-secondary);
+}
 
 /* Timestamp */
 .trade-timestamp {


### PR DESCRIPTION
## Summary
- improve pending trades page layout with grid tiles
- style trade action buttons
- add Counter button to start a new trade
- pre-fill Trading page when opened from a counter offer

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(prints "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68436eaf7a0083309a27e221663ec4ac