### PR TITLE
Fix counter offer pending card check

### DIFF
--- a/backend/README_trading_market.md
+++ b/backend/README_trading_market.md
@@ -56,6 +56,7 @@ This document details the **refactored trading and market system**, including:
   - Recipient has enough packs
   - No cards are `'pending'` in other trades/listings
   - At least one item or pack involved
+- **Optional:** `counterOf` field can reference an existing trade ID when sending a counter offer. Cards pending solely because of that trade are allowed.
 - **Process:**
   - Creates a `Trade` with status `'pending'`
   - Marks involved cards as `'pending'`

--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -15,7 +15,8 @@ const createTrade = async (req, res) => {
     offeredItems: Joi.array().items(Joi.string().hex().length(24)).required(),
     requestedItems: Joi.array().items(Joi.string().hex().length(24)).required(),
     offeredPacks: Joi.number().min(0).required(),
-    requestedPacks: Joi.number().min(0).required()
+    requestedPacks: Joi.number().min(0).required(),
+    counterOf: Joi.string().hex().length(24).optional()
   });
 
   const { error } = tradeSchema.validate(req.body);
@@ -24,11 +25,11 @@ const createTrade = async (req, res) => {
   }
 
   const senderId = req.userId;
-  const { recipient, offeredItems, requestedItems, offeredPacks, requestedPacks } = req.body;
+  const { recipient, offeredItems, requestedItems, offeredPacks, requestedPacks, counterOf } = req.body;
 
   logAudit('Trade Create Attempt', { senderId, body: req.body });
 
-  const result = await tradeService.createTrade(senderId, { recipient, offeredItems, requestedItems, offeredPacks, requestedPacks });
+  const result = await tradeService.createTrade(senderId, { recipient, offeredItems, requestedItems, offeredPacks, requestedPacks, counterOf });
 
   if (!result.success) {
     return res.status(result.status || 500).json({ popupMessage: result.message });

--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -67,6 +67,7 @@ const PendingTrades = () => {
         navigate('/trading', {
             state: {
                 counterOffer: {
+                    tradeId: trade._id,
                     selectedUser: trade.sender.username,
                     tradeOffer: trade.requestedItems,
                     tradeRequest: trade.offeredItems,

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -12,6 +12,7 @@ const TradingPage = ({ userId }) => {
     const [userSuggestions, setUserSuggestions] = useState([]);
     const [selectedUser, setSelectedUser] = useState(null);
     const [showTradePreview, setShowTradePreview] = useState(true);
+    const [counterTradeId, setCounterTradeId] = useState(null);
     const [userCollection, setUserCollection] = useState([]);
     const [recipientCollection, setRecipientCollection] = useState([]);
     const [tradeOffer, setTradeOffer] = useState([]);
@@ -48,6 +49,9 @@ const TradingPage = ({ userId }) => {
             setTradeRequest(counter.tradeRequest || []);
             setOfferedPacks(counter.offeredPacks || 0);
             setRequestedPacks(counter.requestedPacks || 0);
+            setCounterTradeId(counter.tradeId || null);
+        } else {
+            setCounterTradeId(null);
         }
     }, [location.state]);
 
@@ -151,6 +155,9 @@ const TradingPage = ({ userId }) => {
             offeredPacks: Number(offeredPacks),
             requestedPacks: Number(requestedPacks)
         };
+        if (counterTradeId) {
+            tradePayload.counterOf = counterTradeId;
+        }
 
         try {
             await createTrade(tradePayload);


### PR DESCRIPTION
## Summary
- pass the original trade ID when launching a counter offer
- pre-fill the trading form with the countered trade information and keep the trade ID
- allow the API to accept an optional `counterOf` field for counter offers
- skip pending card validation when the cards belong to the trade being countered
- document the new `counterOf` option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844024e306c8330b4bd04397c712bc7