### PR TITLE
Improve trading collections responsiveness

### DIFF
--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -78,11 +78,14 @@
     }
 
 /* Collections & Panels */
+
+/* Collections & Panels */
 .tp-collections-wrapper {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 2rem;
     margin: 2rem 0;
+    width: 100%;
 }
 
 .tp-collection-panel {
@@ -92,6 +95,9 @@
     display: flex;
     flex-direction: column;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    min-width: 0; /* allow shrinking inside grid */
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .tp-collection-header {
@@ -197,11 +203,13 @@
     border: 1px solid var(--border-dark);
     margin-bottom: 2rem;
     padding: 1rem;
-    margin-right: auto;
     overflow: hidden;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
 }
 
 /* Individual Card Item */
@@ -318,6 +326,12 @@
     margin-bottom: 2rem;
 }
 
+/* Container around preview and collections */
+.tp-trade-interface {
+    width: 100%;
+    box-sizing: border-box;
+}
+
 .tp-toggle-preview-button {
     padding: 0.8rem 2rem;
     background: var(--surface-dark);
@@ -388,8 +402,9 @@
 /* Responsive Styles */
 @media (max-width: 768px) {
     .tp-cards-grid {
-        flex-direction: column;
-        align-items: center;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
     }
 
     .tp-trading-container h1 {
@@ -409,6 +424,21 @@
     .tp-trade-preview {
         grid-template-columns: 1fr;
     }
+
+    .tp-collections-wrapper {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .tp-card-preview-wrapper {
+        --tp-card-scale: 0.71;
+    }
+
+    .tp-cards-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem;
+    }
 }
 
 @media (max-width: 480px) {
@@ -417,12 +447,16 @@
     }
 
     .tp-card-item {
-        padding: 0.75rem;
+        padding: 0.5rem;
+    }
+
+    .tp-cards-grid {
+        gap: 0.5rem;
     }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 400px) {
     .tp-card-preview-wrapper {
-        --tp-card-scale: 0.71;
+        --tp-card-scale: 0.6;
     }
 }


### PR DESCRIPTION
## Summary
- tweak card grid columns & gaps across breakpoints
- scale trading cards down further on very small screens

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684406756ebc8330bc65ad5058513bad