### PR TITLE
Improve navbar layout for medium widths

### DIFF
--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -178,9 +178,8 @@
     font-weight: 500;
 }
 
-
-/* Responsive Adjustments */
-@media (max-width: 1024px) {
+/* Collapse navbar links into burger menu on medium screens */
+@media (max-width: 1520px) {
     .burger-button {
         display: flex;
         order: -1;
@@ -216,7 +215,7 @@
     }
 
     .search-wrapper {
-        width: clamp(180px, 50vw, 400px);
+        width: clamp(180px, 40vw, 400px);
     }
 
     .navbar-logo h1 {
@@ -225,6 +224,15 @@
 
     .navbar-username {
         display: none;
+    }
+}
+
+
+
+/* Responsive Adjustments */
+@media (max-width: 1024px) {
+    .search-wrapper {
+        width: clamp(180px, 50vw, 400px);
     }
 }
 


### PR DESCRIPTION
## Summary
- collapse navbar links into burger menu for screens below 1520px
- keep search bar visible with adjusted width

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444bad30cc833098c075458e3039ce