### PR TITLE
Fix burger menu visibility on small screens

### DIFF
--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -148,6 +148,8 @@
     border: none;
     cursor: pointer;
     margin-right: 1rem;
+    position: relative;
+    z-index: 10000; /* keep button visible above overlays */
 }
 
 .burger-bar {


### PR DESCRIPTION
## Summary
- ensure burger menu is always visible by positioning it above overlays

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445746167c83308425fe1dffe2d647