### PR TITLE
Fix burger menu visibility on small screens

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -12,6 +12,7 @@ const Navbar = ({ isAdmin }) => {
     const [isDropdownVisible, setIsDropdownVisible] = useState(false);
     const [loggedInUser, setLoggedInUser] = useState({});
     const [menuOpen, setMenuOpen] = useState(false);
+    const [isMobile, setIsMobile] = useState(typeof window !== 'undefined' ? window.innerWidth <= 480 : false);
 
     // Fetch logged-in user data including profile picture
     useEffect(() => {
@@ -25,6 +26,14 @@ const Navbar = ({ isAdmin }) => {
             }
         };
         fetchUsername();
+    }, []);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth <= 480);
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
     }, []);
 
     const handleLogout = () => {
@@ -76,34 +85,36 @@ const Navbar = ({ isAdmin }) => {
                 <img src="/images/NedsDecksLogo.png" alt="Ned's Decks" />
             </div>
 
-            <div className="navbar-search">
-                <div className="search-wrapper">
-                    <input
-                        type="text"
-                        value={searchQuery}
-                        onChange={handleSearchChange}
-                        placeholder="Search for users..."
-                        className="search-bar"
-                    />
-                    {isDropdownVisible && (
-                        <ul className="search-dropdown">
-                            {searchResults.length > 0 ? (
-                                searchResults.map((user) => (
-                                    <li
-                                        key={user._id}
-                                        onClick={() => handleSearchSelect(user.username)}
-                                        className="search-result-item"
-                                    >
-                                        {user.username}
-                                    </li>
-                                ))
-                            ) : (
-                                <li className="no-results">No users found</li>
-                            )}
-                        </ul>
-                    )}
+            {!isMobile && (
+                <div className="navbar-search">
+                    <div className="search-wrapper">
+                        <input
+                            type="text"
+                            value={searchQuery}
+                            onChange={handleSearchChange}
+                            placeholder="Search for users..."
+                            className="search-bar"
+                        />
+                        {isDropdownVisible && (
+                            <ul className="search-dropdown">
+                                {searchResults.length > 0 ? (
+                                    searchResults.map((user) => (
+                                        <li
+                                            key={user._id}
+                                            onClick={() => handleSearchSelect(user.username)}
+                                            className="search-result-item"
+                                        >
+                                            {user.username}
+                                        </li>
+                                    ))
+                                ) : (
+                                    <li className="no-results">No users found</li>
+                                )}
+                            </ul>
+                        )}
+                    </div>
                 </div>
-            </div>
+            )}
 
             <ul
                 id="primary-navigation"
@@ -167,6 +178,39 @@ const Navbar = ({ isAdmin }) => {
                         Catalogue
                     </NavLink>
                 </li>
+                {isMobile && (
+                    <li className="mobile-search">
+                        <div className="search-wrapper">
+                            <input
+                                type="text"
+                                value={searchQuery}
+                                onChange={handleSearchChange}
+                                placeholder="Search for users..."
+                                className="search-bar"
+                            />
+                            {isDropdownVisible && (
+                                <ul className="search-dropdown">
+                                    {searchResults.length > 0 ? (
+                                        searchResults.map((user) => (
+                                            <li
+                                                key={user._id}
+                                                onClick={() => {
+                                                    handleSearchSelect(user.username);
+                                                    setMenuOpen(false);
+                                                }}
+                                                className="search-result-item"
+                                            >
+                                                {user.username}
+                                            </li>
+                                        ))
+                                    ) : (
+                                        <li className="no-results">No users found</li>
+                                    )}
+                                </ul>
+                            )}
+                        </div>
+                    </li>
+                )}
             </ul>
 
             {/* Render NotificationDropdown only when loggedInUser._id is available */}

--- a/frontend/src/styles/Navbar.css
+++ b/frontend/src/styles/Navbar.css
@@ -127,6 +127,10 @@
     transition: color 0.3s ease, transform 0.3s ease;
 }
 
+.mobile-search {
+    display: none;
+}
+
     .nav-link.active {
         font-weight: bold;
         color: var(--brand-primary);
@@ -148,6 +152,8 @@
     border: none;
     cursor: pointer;
     margin-right: 1rem;
+    position: relative;
+    z-index: 10000; /* keep button visible above overlays */
 }
 
 .burger-bar {
@@ -163,11 +169,12 @@
     max-height: 60px;
     width: auto; /* Keep aspect ratio */
     object-fit: contain;
+    max-width: 120px;
 }
 
 /* Add this rule or update your existing .navbar-notifications */
 .navbar-notifications {
-    margin-left: 20px;
+    margin-left: auto;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -237,6 +244,13 @@
 }
 
 @media (max-width: 480px) {
+    .navbar-search {
+        display: none;
+    }
+    .mobile-search {
+        display: block;
+        width: 100%;
+    }
     .search-bar {
         width: 100%;
     }


### PR DESCRIPTION
## Summary
- hide search bar in navbar for screens <480px and render it in the dropdown
- limit logo width so the burger button isn't pushed off-screen
- keep burger menu visible with higher z-index (from previous commit)
- always keep profile avatar at the far right

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445746167c83308425fe1dffe2d647