### PR TITLE
Improve featured card feedback

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -215,13 +215,26 @@ const CollectionPage = ({
         if (!loggedInUser) return;
         const isCurrentlyFeatured = featuredCards.some((fc) => fc._id === card._id);
         if (!isCurrentlyFeatured && featuredCards.length >= 4) {
-            console.warn('Max 4 featured cards allowed!');
+            if (window.showToast) {
+                window.showToast('You can only feature up to 4 cards.', 'warning');
+            }
             return;
         }
         try {
             await handleToggleFeatured(card);
+            if (window.showToast) {
+                window.showToast(
+                    isCurrentlyFeatured
+                        ? 'Card removed from featured collection.'
+                        : 'Card added to featured collection.',
+                    'success'
+                );
+            }
         } catch (error) {
             console.error(error);
+            if (window.showToast) {
+                window.showToast('Error updating featured cards.', 'error');
+            }
         }
         const cardElement = document.getElementById(`cp-card-${card._id}`);
         if (cardElement) {
@@ -254,8 +267,14 @@ const CollectionPage = ({
             await updateFeaturedCards([]);
             const response = await fetchFeaturedCards();
             setFeaturedCards(response.featuredCards || []);
+            if (window.showToast) {
+                window.showToast('Featured cards cleared.', 'success');
+            }
         } catch (error) {
             console.error('Error clearing featured cards:', error);
+            if (window.showToast) {
+                window.showToast('Error clearing featured cards.', 'error');
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- add toast notifications for adding/removing featured cards
- warn when the max number of featured cards is reached
- notify when clearing all featured cards

## Testing
- `CI=true npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68448c7193a483309a24a021ea170da6