### PR TITLE
Improve pending trades UI

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -143,18 +143,25 @@ const PendingTrades = () => {
                     const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'}`;
                     const isExpanded = expandedTrades[trade._id];
 
+                    const offeredCount = trade.offeredItems?.length || 0;
+                    const requestedCount = trade.requestedItems?.length || 0;
+                    const tradeSummary = `${offeredCount} item(s) & ${trade.offeredPacks} pack(s) for ${requestedCount} item(s) & ${trade.requestedPacks} pack(s)`;
+
                     return (
                         <div
                             key={trade._id}
-                            className={tradeStatusClass}
+                            className={`${tradeStatusClass} ${isExpanded ? 'expanded' : ''}`}
                             onClick={() => toggleTrade(trade._id)}
                         >
                             <div className="trade-header">
                                 <div className="trade-header-info">
-                                    {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
-                                    <span>
-                                        with {isOutgoing ? trade.recipient.username : trade.sender.username}
-                                    </span>
+                                    <div className="trade-title">
+                                        {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
+                                        <span>
+                                            with {isOutgoing ? trade.recipient.username : trade.sender.username}
+                                        </span>
+                                    </div>
+                                    <div className="trade-summary">{tradeSummary}</div>
                                 </div>
                                 {isExpanded && (
                                     <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -85,6 +85,10 @@
     position: relative;
 }
 
+.trade-card.expanded {
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+}
+
     .trade-card:hover {
         transform: translateY(-2px);
     }
@@ -106,6 +110,24 @@
     font-size: 1.5rem;
     font-weight: 500;
     margin-bottom: 0.5rem;
+}
+
+.trade-header-info {
+    flex: 1;
+}
+
+.trade-title {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 1.2rem;
+    line-height: 1.2;
+}
+
+.trade-summary {
+    font-size: 0.9rem;
+    opacity: 0.8;
+    margin-top: 0.25rem;
 }
 
     .trade-header span {
@@ -179,6 +201,9 @@
 /* Trade Content */
 .trade-content {
     margin-bottom: 1rem;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
 }
 
 /* Trade Sections (Offer/Request) */
@@ -226,5 +251,9 @@
     .filters {
         flex-direction: column;
         align-items: center;
+    }
+
+    .trade-content {
+        grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
## Summary
- restructure PendingTrades cards with summary text and expanded state
- adjust PendingTrades styles for grid layout and small screen responsiveness

## Testing
- `npm test --prefix frontend --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684573a441388330b32003d888d5b0c2