### PR TITLE
Refine Pending Trades UX

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -14,7 +14,7 @@ const PendingTrades = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const [filter, setFilter] = useState('all');
     const [sortOrder, setSortOrder] = useState('newest');
-    const [expandedTrades, setExpandedTrades] = useState({});
+    const [expandedTradeId, setExpandedTradeId] = useState(null);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -83,10 +83,7 @@ const PendingTrades = () => {
     const handleSortChange = (e) => setSortOrder(e.target.value);
 
     const toggleTrade = (tradeId) => {
-        setExpandedTrades((prevState) => ({
-            ...prevState,
-            [tradeId]: !prevState[tradeId],
-        }));
+        setExpandedTradeId((prev) => (prev === tradeId ? null : tradeId));
     };
 
     const filteredAndSortedTrades = pendingTrades
@@ -141,20 +138,60 @@ const PendingTrades = () => {
                 {filteredAndSortedTrades.map((trade) => {
                     const isOutgoing = trade.sender._id === loggedInUser._id;
                     const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'}`;
-                    const isExpanded = expandedTrades[trade._id];
+                    const isExpanded = expandedTradeId === trade._id;
+                    const previewOffered = trade.offeredItems?.slice(0, 2) || [];
+                    const previewRequested = trade.requestedItems?.slice(0, 2) || [];
+
+                    const offeredCount = trade.offeredItems?.length || 0;
+                    const requestedCount = trade.requestedItems?.length || 0;
+                    const tradeSummary = `${offeredCount} item(s) & ${trade.offeredPacks} pack(s) for ${requestedCount} item(s) & ${trade.requestedPacks} pack(s)`;
 
                     return (
                         <div
                             key={trade._id}
-                            className={tradeStatusClass}
+                            className={`${tradeStatusClass} ${isExpanded ? 'expanded' : ''}`}
                             onClick={() => toggleTrade(trade._id)}
                         >
                             <div className="trade-header">
                                 <div className="trade-header-info">
-                                    {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
-                                    <span>
-                                        with {isOutgoing ? trade.recipient.username : trade.sender.username}
-                                    </span>
+                                    <div className="trade-title">
+                                        {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
+                                        <span>
+                                            with {isOutgoing ? trade.recipient.username : trade.sender.username}
+                                        </span>
+                                    </div>
+                                    <div className="trade-summary">{tradeSummary}</div>
+                                    <div className="trade-overview">
+                                        <div className="overview-section">
+                                            {previewOffered.map((item) => (
+                                                <img
+                                                    key={item._id}
+                                                    src={item.imageUrl}
+                                                    alt={item.name}
+                                                    className="trade-thumb"
+                                                />
+                                            ))}
+                                            {trade.offeredItems?.length > 2 && (
+                                                <span className="thumb-more">+{trade.offeredItems.length - 2}</span>
+                                            )}
+                                            <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
+                                        </div>
+                                        <div className="trade-arrow">for</div>
+                                        <div className="overview-section">
+                                            {previewRequested.map((item) => (
+                                                <img
+                                                    key={item._id}
+                                                    src={item.imageUrl}
+                                                    alt={item.name}
+                                                    className="trade-thumb"
+                                                />
+                                            ))}
+                                            {trade.requestedItems?.length > 2 && (
+                                                <span className="thumb-more">+{trade.requestedItems.length - 2}</span>
+                                            )}
+                                            <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
+                                        </div>
+                                    </div>
                                 </div>
                                 {isExpanded && (
                                     <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -13,10 +13,10 @@
 /* Main container for the pending trades page */
 .pending-trades-container {
     background: var(--surface-dark);
-    padding: 2rem;
+    padding: 2rem 1.5rem;
     border-radius: var(--border-radius);
-    margin: 2rem auto;
-    max-width: 1200px;
+    margin: 1rem 0;
+    max-width: 100%;
     color: var(--text-primary);
     box-sizing: border-box;
 }
@@ -56,7 +56,7 @@
 .trades-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
+    gap: 2rem;
 }
 
     .filters input,
@@ -78,11 +78,15 @@
 .trade-card {
     background: var(--surface-dark);
     border-radius: var(--border-radius);
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
+    padding: 2rem;
+    margin-bottom: 2rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     transition: var(--transition);
     position: relative;
+}
+
+.trade-card.expanded {
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
 }
 
     .trade-card:hover {
@@ -106,6 +110,61 @@
     font-size: 1.5rem;
     font-weight: 500;
     margin-bottom: 0.5rem;
+}
+
+.trade-header-info {
+    flex: 1;
+}
+
+.trade-title {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 1.2rem;
+    line-height: 1.2;
+}
+
+.trade-summary {
+    font-size: 0.9rem;
+    opacity: 0.8;
+    margin-top: 0.25rem;
+}
+
+.trade-overview {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.overview-section {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.trade-thumb {
+    width: 40px;
+    height: 56px;
+    object-fit: cover;
+    border-radius: 4px;
+}
+
+.thumb-more {
+    font-size: 0.8rem;
+    color: #bbb;
+}
+
+.packs-chip {
+    background: var(--surface-darker);
+    border-radius: 12px;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+}
+
+.trade-arrow {
+    font-weight: 600;
 }
 
     .trade-header span {
@@ -179,15 +238,18 @@
 /* Trade Content */
 .trade-content {
     margin-bottom: 1rem;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
 }
 
 /* Trade Sections (Offer/Request) */
 .trade-section {
     background: var(--surface-dark);
     border: 1px solid var(--border-dark);
-    padding: 1rem;
+    padding: 1.25rem;
     border-radius: var(--border-radius);
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 }
 
     .trade-section h4 {
@@ -226,5 +288,10 @@
     .filters {
         flex-direction: column;
         align-items: center;
+    }
+
+    .trade-content {
+        grid-template-columns: 1fr;
+        gap: 1rem;
     }
 }


### PR DESCRIPTION
## Summary
- expand pending trades container width
- track a single expanded trade instead of many
- display trade thumbnails and pack counts for quick overview

## Testing
- `npm test --prefix frontend --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_684573a441388330b32003d888d5b0c2