### PR TITLE
Simplify Pending Trades UI

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -14,7 +14,6 @@ const PendingTrades = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const [filter, setFilter] = useState('all');
     const [sortOrder, setSortOrder] = useState('newest');
-    const [expandedTrades, setExpandedTrades] = useState({});
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -82,12 +81,6 @@ const PendingTrades = () => {
     const handleFilterChange = (e) => setFilter(e.target.value);
     const handleSortChange = (e) => setSortOrder(e.target.value);
 
-    const toggleTrade = (tradeId) => {
-        setExpandedTrades((prevState) => ({
-            ...prevState,
-            [tradeId]: !prevState[tradeId],
-        }));
-    };
 
     const filteredAndSortedTrades = pendingTrades
         .filter((trade) => {
@@ -141,107 +134,88 @@ const PendingTrades = () => {
                 {filteredAndSortedTrades.map((trade) => {
                     const isOutgoing = trade.sender._id === loggedInUser._id;
                     const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'}`;
-                    const isExpanded = expandedTrades[trade._id];
+
+                    const offeredItemsCount = trade.offeredItems?.length || 0;
+                    const requestedItemsCount = trade.requestedItems?.length || 0;
+                    const tradeSummary = `${offeredItemsCount} item(s) & ${trade.offeredPacks} pack(s) for ${requestedItemsCount} item(s) & ${trade.requestedPacks} pack(s)`;
 
                     return (
                         <div
                             key={trade._id}
                             className={tradeStatusClass}
-                            onClick={() => toggleTrade(trade._id)}
                         >
                             <div className="trade-header">
                                 <div className="trade-header-info">
-                                    {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
-                                    <span>
-                                        with {isOutgoing ? trade.recipient.username : trade.sender.username}
-                                    </span>
-                                </div>
-                                {isExpanded && (
-                                    <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>
-                                        {!isOutgoing ? (
-                                            <>
-                                                <button
-                                                    className="accept-button"
-                                                    onClick={(e) => handleTradeAction(trade._id, 'accept', e)}
-                                                >
-                                                    Accept
-                                                </button>
-                                                <button
-                                                    className="reject-button"
-                                                    onClick={(e) => handleTradeAction(trade._id, 'reject', e)}
-                                                >
-                                                    Reject
-                                                </button>
-                                                <button
-                                                    className="counter-button"
-                                                    onClick={(e) => handleCounterOffer(trade, e)}
-                                                >
-                                                    Counter
-                                                </button>
-                                            </>
-                                        ) : (
-                                            <button
-                                                className="cancel-button"
-                                                onClick={(e) => handleTradeAction(trade._id, 'cancel', e)}
-                                            >
-                                                Cancel Trade
-                                            </button>
-                                        )}
+                                    <div className="trade-title">
+                                        {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
+                                        <span>
+                                            with {isOutgoing ? trade.recipient.username : trade.sender.username}
+                                        </span>
                                     </div>
-                                )}
+                                    <div className="trade-summary">{tradeSummary}</div>
+                                    <div className="trade-overview">
+                                        <div className="overview-section">
+                                            {trade.offeredItems?.map((item) => (
+                                                <img
+                                                    key={item._id}
+                                                    src={item.imageUrl}
+                                                    alt={item.name}
+                                                    className="trade-thumb"
+                                                />
+                                            ))}
+                                            <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
+                                        </div>
+                                        <div className="trade-arrow">for</div>
+                                        <div className="overview-section">
+                                            {trade.requestedItems?.map((item) => (
+                                                <img
+                                                    key={item._id}
+                                                    src={item.imageUrl}
+                                                    alt={item.name}
+                                                    className="trade-thumb"
+                                                />
+                                            ))}
+                                            <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>
+                                    {!isOutgoing ? (
+                                        <>
+                                            <button
+                                                className="accept-button"
+                                                onClick={(e) => handleTradeAction(trade._id, 'accept', e)}
+                                            >
+                                                Accept
+                                            </button>
+                                            <button
+                                                className="reject-button"
+                                                onClick={(e) => handleTradeAction(trade._id, 'reject', e)}
+                                            >
+                                                Reject
+                                            </button>
+                                            <button
+                                                className="counter-button"
+                                                onClick={(e) => handleCounterOffer(trade, e)}
+                                            >
+                                                Counter
+                                            </button>
+                                        </>
+                                    ) : (
+                                        <button
+                                            className="cancel-button"
+                                            onClick={(e) => handleTradeAction(trade._id, 'cancel', e)}
+                                        >
+                                            Cancel Trade
+                                        </button>
+                                    )}
+                                </div>
                             </div>
 
                             <div className="trade-timestamp">
                                 Created on: {new Date(trade.createdAt).toLocaleString()}
                             </div>
 
-                            <div className={`trade-content-wrapper ${isExpanded ? 'expanded' : ''}`}>
-                                <div className="trade-content">
-                                    <div className="trade-section">
-                                        <h4>Offered Items</h4>
-                                        <div className="cards-grid">
-                                            {trade.offeredItems?.length > 0 ? (
-                                                trade.offeredItems.map((item) => (
-                                                    <BaseCard
-                                                        key={item._id}
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                        maxMint={item.maxMint || '???'}
-                                                    />
-                                                ))
-                                            ) : (
-                                                <p>No offered items.</p>
-                                            )}
-                                        </div>
-                                        <p className="packs-info">Packs Offered: {trade.offeredPacks}</p>
-                                    </div>
-
-                                    <div className="trade-section">
-                                        <h4>Requested Items</h4>
-                                        <div className="cards-grid">
-                                            {trade.requestedItems?.length > 0 ? (
-                                                trade.requestedItems.map((item) => (
-                                                    <BaseCard
-                                                        key={item._id}
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                        maxMint={item.maxMint || '???'}
-                                                    />
-                                                ))
-                                            ) : (
-                                                <p>No requested items.</p>
-                                            )}
-                                        </div>
-                                        <p className="packs-info">Packs Requested: {trade.requestedPacks}</p>
-                                    </div>
-                                </div>
-                            </div>
                         </div>
                     );
                 })}

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -13,10 +13,10 @@
 /* Main container for the pending trades page */
 .pending-trades-container {
     background: var(--surface-dark);
-    padding: 2rem;
+    padding: 2rem 1.5rem;
     border-radius: var(--border-radius);
-    margin: 2rem auto;
-    max-width: 1200px;
+    margin: 1rem 0;
+    max-width: 100%;
     color: var(--text-primary);
     box-sizing: border-box;
 }
@@ -56,7 +56,7 @@
 .trades-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
+    gap: 2rem;
 }
 
     .filters input,
@@ -78,12 +78,13 @@
 .trade-card {
     background: var(--surface-dark);
     border-radius: var(--border-radius);
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
+    padding: 2rem;
+    margin-bottom: 2rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     transition: var(--transition);
     position: relative;
 }
+
 
     .trade-card:hover {
         transform: translateY(-2px);
@@ -106,6 +107,61 @@
     font-size: 1.5rem;
     font-weight: 500;
     margin-bottom: 0.5rem;
+}
+
+.trade-header-info {
+    flex: 1;
+}
+
+.trade-title {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 1.2rem;
+    line-height: 1.2;
+}
+
+.trade-summary {
+    font-size: 0.9rem;
+    opacity: 0.8;
+    margin-top: 0.25rem;
+}
+
+.trade-overview {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.overview-section {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.trade-thumb {
+    width: 40px;
+    height: 56px;
+    object-fit: cover;
+    border-radius: 4px;
+}
+
+.thumb-more {
+    font-size: 0.8rem;
+    color: #bbb;
+}
+
+.packs-chip {
+    background: var(--surface-darker);
+    border-radius: 12px;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+}
+
+.trade-arrow {
+    font-weight: 600;
 }
 
     .trade-header span {
@@ -161,57 +217,6 @@
     margin-bottom: 1rem;
 }
 
-/* Trade content wrapper for smooth expand/collapse */
-.trade-content-wrapper {
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transition: max-height 0.5s ease, opacity 0.5s ease;
-}
-
-    .trade-content-wrapper.expanded {
-        max-height: 1200px; /* Increased max-height to ensure full content visibility */
-        opacity: 1;
-        overflow: visible; /* Allow overflow so both sides are visible */
-        margin-bottom: 1rem; /* Extra space so buttons are not overlapped */
-    }
-
-/* Trade Content */
-.trade-content {
-    margin-bottom: 1rem;
-}
-
-/* Trade Sections (Offer/Request) */
-.trade-section {
-    background: var(--surface-dark);
-    border: 1px solid var(--border-dark);
-    padding: 1rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 1rem;
-}
-
-    .trade-section h4 {
-        font-size: 1.2rem;
-        font-weight: 500;
-        margin-bottom: 0.75rem;
-        color: var(--text-primary);
-    }
-
-/* Cards Grid inside a trade section */
-.cards-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-}
-
-/* Packs Info */
-.packs-info {
-    margin-top: 0.5rem;
-    font-weight: 600;
-    text-align: center;
-}
-
 /* Error and No Trades Messages */
 .error-message,
 .no-trades {
@@ -227,4 +232,5 @@
         flex-direction: column;
         align-items: center;
     }
+
 }


### PR DESCRIPTION
## Summary
- remove expandable card logic in PendingTrades
- show all offered and requested item thumbnails directly in each tile
- drop unused expansion styles

## Testing
- `npm test --prefix frontend --silent --yes`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684573a441388330b32003d888d5b0c2