### PR TITLE
Enhance pending trades preview

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchUserProfile, fetchPendingTrades, acceptTrade, rejectTrade, cancelTrade } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner'; // Import the spinner
+import BaseCard from '../components/BaseCard';
 import '../styles/PendingTrades.css';
 
 const PendingTrades = () => {
@@ -79,6 +80,28 @@ const PendingTrades = () => {
     const handleFilterChange = (e) => setFilter(e.target.value);
     const handleSortChange = (e) => setSortOrder(e.target.value);
 
+    const renderCardPreview = (cards = []) => {
+        const preview = cards.slice(0, 3);
+        return (
+            <div className="preview-cards">
+                {preview.map((item) => (
+                    <div key={item._id} className="trade-preview">
+                        <BaseCard
+                            name={item.name}
+                            image={item.imageUrl}
+                            rarity={item.rarity}
+                            description={item.flavorText}
+                            mintNumber={item.mintNumber}
+                        />
+                    </div>
+                ))}
+                {cards.length > preview.length && (
+                    <span className="thumb-more">+{cards.length - preview.length} more</span>
+                )}
+            </div>
+        );
+    };
+
 
     const filteredAndSortedTrades = pendingTrades
         .filter((trade) => {
@@ -145,35 +168,20 @@ const PendingTrades = () => {
                             <div className="trade-header">
                                 <div className="trade-header-info">
                                     <div className="trade-title">
-                                        {isOutgoing ? 'Outgoing Trade' : 'Incoming Trade'}{' '}
+                                        {isOutgoing ? 'Outgoing to' : 'Incoming from'}{' '}
                                         <span>
-                                            with {isOutgoing ? trade.recipient.username : trade.sender.username}
+                                            {isOutgoing ? trade.recipient.username : trade.sender.username}
                                         </span>
                                     </div>
                                     <div className="trade-summary">{tradeSummary}</div>
                                     <div className="trade-overview">
                                         <div className="overview-section">
-                                            {trade.offeredItems?.map((item) => (
-
-                                                <img
-                                                    key={item._id}
-                                                    src={item.imageUrl}
-                                                    alt={item.name}
-                                                    className="trade-thumb"
-                                                />
-                                            ))}
+                                            {renderCardPreview(trade.offeredItems)}
                                             <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
                                         </div>
                                         <div className="trade-arrow">for</div>
                                         <div className="overview-section">
-                                            {trade.requestedItems?.map((item) => (
-                                                <img
-                                                    key={item._id}
-                                                    src={item.imageUrl}
-                                                    alt={item.name}
-                                                    className="trade-thumb"
-                                                />
-                                            ))}
+                                            {renderCardPreview(trade.requestedItems)}
                                             <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
                                         </div>
                                     </div>

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -141,16 +141,27 @@
     gap: 0.25rem;
 }
 
-.trade-thumb {
-    width: 40px;
-    height: 56px;
-    object-fit: cover;
-    border-radius: 4px;
+.preview-cards {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.trade-preview {
+    width: 80px;
+    max-width: 80px;
+}
+
+.trade-preview .card-container {
+    margin: 0 !important;
+    max-width: 100% !important;
 }
 
 .thumb-more {
     font-size: 0.8rem;
     color: #bbb;
+    padding-left: 0.25rem;
+    display: inline-block;
 }
 
 .packs-chip {


### PR DESCRIPTION
## Summary
- show full BaseCard preview for trade items
- adjust PendingTrades styles for scaled cards

## Testing
- `npm test --silent` *(no tests defined)*
- `npm test --silent` in backend *(fails: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2d950708330ae9368bf7708a66c