### PR TITLE
Refactor PendingTrades layout

### DIFF
--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -53,10 +53,10 @@
 }
 
 /* Grid layout for trade tiles */
-.trades-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 2rem;
+.trades-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
     .filters input,
@@ -79,10 +79,11 @@
     background: var(--surface-dark);
     border-radius: var(--border-radius);
     padding: 2rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     transition: var(--transition);
     position: relative;
+    width: 100%;
 }
 
 
@@ -141,16 +142,27 @@
     gap: 0.25rem;
 }
 
-.trade-thumb {
-    width: 40px;
-    height: 56px;
-    object-fit: cover;
-    border-radius: 4px;
+.preview-cards {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.trade-preview {
+    width: 150px;
+    max-width: 150px;
+}
+
+.trade-preview .card-container {
+    margin: 0 !important;
+    max-width: 100% !important;
 }
 
 .thumb-more {
     font-size: 0.8rem;
     color: #bbb;
+    padding-left: 0.25rem;
+    display: inline-block;
 }
 
 .packs-chip {
@@ -210,6 +222,39 @@
     background-color: var(--brand-secondary);
 }
 
+/* Expanded trade details */
+.trade-card {
+    cursor: pointer;
+}
+
+.trade-details {
+    margin-top: 1rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.trade-section h3 {
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+}
+
+.cards-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.full-card {
+    width: 300px;
+    max-width: 300px;
+}
+
+.full-card .card-container {
+    margin: 0 !important;
+    max-width: 100% !important;
+}
+
 /* Timestamp */
 .trade-timestamp {
     font-size: 0.9rem;
@@ -233,4 +278,12 @@
         align-items: center;
     }
 
+    .trade-overview {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .trade-buttons-inline {
+        margin-top: 0.5rem;
+    }
 }


### PR DESCRIPTION
## Summary
- display pending trades in a list instead of a grid
- enlarge previews and full cards using existing BaseCard styles
- make overview responsive on small screens

## Testing
- `npm test --silent` *(no output)*
- `npm test --silent` in `backend` *(fails: no test specified)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2d950708330ae9368bf7708a66c