### PR TITLE
Improve pending trades layout

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -1,280 +1,215 @@
-// src/pages/PendingTrades.js
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchUserProfile, fetchPendingTrades, acceptTrade, rejectTrade, cancelTrade } from '../utils/api';
-import LoadingSpinner from '../components/LoadingSpinner'; // Import the spinner
+import LoadingSpinner from '../components/LoadingSpinner';
 import BaseCard from '../components/BaseCard';
 import '../styles/PendingTrades.css';
 
 const PendingTrades = () => {
-    const [pendingTrades, setPendingTrades] = useState([]);
-    const [loggedInUser, setLoggedInUser] = useState(null);
-    const [error, setError] = useState(null);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [filter, setFilter] = useState('all');
-    const [sortOrder, setSortOrder] = useState('newest');
-    const [expandedTrade, setExpandedTrade] = useState(null);
-    const navigate = useNavigate();
+  const [trades, setTrades] = useState([]);
+  const [user, setUser] = useState(null);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortOrder, setSortOrder] = useState('newest');
+  const navigate = useNavigate();
 
-    useEffect(() => {
-        const loadUserProfile = async () => {
-            try {
-                const profile = await fetchUserProfile();
-                setLoggedInUser(profile);
-                loadPendingTrades(profile._id);
-            } catch (err) {
-                console.error('Failed to fetch user profile:', err.message);
-                setError('Failed to fetch user profile');
-            }
-        };
-        loadUserProfile();
-    }, []);
-
-    const loadPendingTrades = async (userId) => {
-        try {
-            const trades = await fetchPendingTrades(userId);
-            setPendingTrades(trades);
-        } catch (err) {
-            console.error('Failed to fetch pending trades:', err);
-            setError('Failed to load pending trades');
-        }
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const profile = await fetchUserProfile();
+        setUser(profile);
+        const data = await fetchPendingTrades(profile._id);
+        setTrades(data);
+      } catch (err) {
+        console.error('Failed to load trades:', err);
+        setError('Failed to load pending trades');
+      }
     };
+    load();
+  }, []);
 
-    const handleTradeAction = async (tradeId, action, e) => {
-        e.stopPropagation();
-        const confirmationMessage = {
-            accept: 'Are you sure you want to accept this trade?',
-            reject: 'Are you sure you want to reject this trade?',
-            cancel: 'Are you sure you want to cancel this trade?'
-        };
-
-        if (window.confirm(confirmationMessage[action])) {
-            try {
-                if (action === 'accept') await acceptTrade(tradeId, loggedInUser._id);
-                if (action === 'reject') await rejectTrade(tradeId, loggedInUser._id);
-                if (action === 'cancel') await cancelTrade(tradeId, loggedInUser._id);
-                loadPendingTrades(loggedInUser._id);
-            } catch (err) {
-                console.error(`Error ${action}ing trade:`, err);
-                setError(`Failed to ${action} trade`);
-            }
-        }
-    };
-
-    const handleCounterOffer = (trade, e) => {
-        e.stopPropagation();
-        navigate('/trading', {
-            state: {
-                counterOffer: {
-                    tradeId: trade._id,
-                    selectedUser: trade.sender.username,
-                    tradeOffer: trade.requestedItems,
-                    tradeRequest: trade.offeredItems,
-                    offeredPacks: trade.requestedPacks,
-                    requestedPacks: trade.offeredPacks,
-                },
-            },
-        });
-    };
-
-    const handleSearch = (e) => setSearchQuery(e.target.value.toLowerCase());
-    const handleFilterChange = (e) => setFilter(e.target.value);
-    const handleSortChange = (e) => setSortOrder(e.target.value);
-    const toggleTrade = (tradeId) => {
-        setExpandedTrade((prev) => (prev === tradeId ? null : tradeId));
-    };
-
-    const cardPreview = (cards = []) => {
-        const preview = cards.slice(0, 3);
-        return (
-            <div className="preview-cards">
-                {preview.map((item) => (
-                    <div key={item._id} className="trade-preview">
-                        <BaseCard
-                            name={item.name}
-                            image={item.imageUrl}
-                            rarity={item.rarity}
-                            description={item.flavorText}
-                            mintNumber={item.mintNumber}
-                        />
-                    </div>
-                ))}
-                {cards.length > preview.length && (
-                    <span className="thumb-more">+{cards.length - preview.length} more</span>
-                )}
-            </div>
-        );
-    };
-
-
-    const filteredAndSortedTrades = pendingTrades
-        .filter((trade) => {
-            if (trade.status !== 'pending') return false;
-            const isIncoming = trade.recipient._id === loggedInUser._id;
-            const isOutgoing = trade.sender._id === loggedInUser._id;
-            if (filter === 'incoming' && !isIncoming) return false;
-            if (filter === 'outgoing' && !isOutgoing) return false;
-            const otherParty = isIncoming ? trade.sender.username : trade.recipient.username;
-            return otherParty.toLowerCase().includes(searchQuery);
-        })
-        .sort((a, b) => {
-            if (sortOrder === 'newest') return new Date(b.createdAt) - new Date(a.createdAt);
-            return new Date(a.createdAt) - new Date(b.createdAt);
-        });
-
-    if (error) return <div className="error-message">{error}</div>;
-
-    if (!loggedInUser) {
-        // If still loading user data, display the global spinner.
-        return <LoadingSpinner />;
+  const refreshTrades = async () => {
+    if (!user) return;
+    try {
+      const data = await fetchPendingTrades(user._id);
+      setTrades(data);
+    } catch (err) {
+      console.error('Failed to refresh trades:', err);
+      setError('Failed to refresh trades');
     }
+  };
 
-    return (
-        <div className="pending-trades-container">
-            <h1 className="page-title">Pending Trades</h1>
+  const handleAction = async (id, action) => {
+    const messages = {
+      accept: 'Are you sure you want to accept this trade?',
+      reject: 'Are you sure you want to reject this trade?',
+      cancel: 'Are you sure you want to cancel this trade?',
+    };
+    if (!window.confirm(messages[action])) return;
+    try {
+      if (action === 'accept') await acceptTrade(id, user._id);
+      if (action === 'reject') await rejectTrade(id, user._id);
+      if (action === 'cancel') await cancelTrade(id, user._id);
+      refreshTrades();
+    } catch (err) {
+      console.error(`Failed to ${action} trade:`, err);
+      setError(`Failed to ${action} trade`);
+    }
+  };
 
-            <div className="filters">
-                <input
-                    type="text"
-                    placeholder="Search by username..."
-                    value={searchQuery}
-                    onChange={handleSearch}
-                    className="search-box"
-                />
-                <select value={filter} onChange={handleFilterChange} className="filter-dropdown">
-                    <option value="all">All Trades</option>
-                    <option value="incoming">Incoming Trades</option>
-                    <option value="outgoing">Outgoing Trades</option>
-                </select>
-                <select value={sortOrder} onChange={handleSortChange} className="sort-dropdown">
-                    <option value="newest">Newest First</option>
-                    <option value="oldest">Oldest First</option>
-                </select>
-            </div>
+  const handleCounter = (trade) => {
+    navigate('/trading', {
+      state: {
+        counterOffer: {
+          tradeId: trade._id,
+          selectedUser: trade.sender.username,
+          tradeOffer: trade.requestedItems,
+          tradeRequest: trade.offeredItems,
+          offeredPacks: trade.requestedPacks,
+          requestedPacks: trade.offeredPacks,
+        },
+      },
+    });
+  };
 
-            {filteredAndSortedTrades.length === 0 ? (
-                <p className="no-trades">No pending trades.</p>
-            ) : (
-                <div className="trades-list">
-                {filteredAndSortedTrades.map((trade) => {
-                    const isOutgoing = trade.sender._id === loggedInUser._id;
-                    const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'} ${expandedTrade === trade._id ? 'expanded' : 'collapsed'}`;
+  if (error) return <div className="error-message">{error}</div>;
+  if (!user) return <LoadingSpinner />;
 
-                    const offeredItemsCount = trade.offeredItems?.length || 0;
-                    const requestedItemsCount = trade.requestedItems?.length || 0;
-                    const tradeSummary = `${offeredItemsCount} item(s) & ${trade.offeredPacks} pack(s) for ${requestedItemsCount} item(s) & ${trade.requestedPacks} pack(s)`;
+  const pending = trades.filter((t) => t.status === 'pending');
 
-                    return (
-                        <div
-                            key={trade._id}
-                            className={tradeStatusClass}
-                            onClick={() => toggleTrade(trade._id)}
-                        >
-                            <div className="trade-header">
-                                <div className="trade-header-info">
-                                    <div className="trade-title">
-                                        {isOutgoing ? 'Outgoing to' : 'Incoming from'}{' '}
-                                        <span>
-                                            {isOutgoing ? trade.recipient.username : trade.sender.username}
-                                        </span>
-                                    </div>
-                                    <div className="trade-summary">{tradeSummary}</div>
-                                    <div className="trade-overview">
-                                        <div className="overview-section">
-                                            {cardPreview(trade.offeredItems)}
-                                            <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
-                                        </div>
-                                        <div className="trade-arrow">for</div>
-                                        <div className="overview-section">
-                                            {cardPreview(trade.requestedItems)}
-                                            <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>
-                                    {!isOutgoing ? (
-                                        <>
-                                            <button
-                                                className="accept-button"
-                                                onClick={(e) => handleTradeAction(trade._id, 'accept', e)}
-                                            >
-                                                Accept
-                                            </button>
-                                            <button
-                                                className="reject-button"
-                                                onClick={(e) => handleTradeAction(trade._id, 'reject', e)}
-                                            >
-                                                Reject
-                                            </button>
-                                            <button
-                                                className="counter-button"
-                                                onClick={(e) => handleCounterOffer(trade, e)}
-                                            >
-                                                Counter
-                                            </button>
-                                        </>
-                                    ) : (
-                                        <button
-                                            className="cancel-button"
-                                            onClick={(e) => handleTradeAction(trade._id, 'cancel', e)}
-                                        >
-                                            Cancel Trade
-                                        </button>
-                                    )}
-                                </div>
-                            </div>
+  const sortFn = (a, b) =>
+    sortOrder === 'newest'
+      ? new Date(b.createdAt) - new Date(a.createdAt)
+      : new Date(a.createdAt) - new Date(b.createdAt);
 
-                            <div className="trade-timestamp">
-                                Created on: {new Date(trade.createdAt).toLocaleString()}
-                            </div>
+  const incoming = pending
+    .filter((t) => t.recipient._id === user._id)
+    .filter((t) => t.sender.username.toLowerCase().includes(searchQuery.toLowerCase()))
+    .sort(sortFn);
+  const outgoing = pending
+    .filter((t) => t.sender._id === user._id)
+    .filter((t) => t.recipient.username.toLowerCase().includes(searchQuery.toLowerCase()))
+    .sort(sortFn);
 
-                            {expandedTrade === trade._id && (
-                                <div className="trade-details" onClick={(e) => e.stopPropagation()}>
-                                    <div className="trade-section">
-                                        <h3>Offered Items</h3>
-                                        <div className="cards-grid">
-                                            {trade.offeredItems?.map((item) => (
-                                                <div key={item._id} className="full-card">
-                                                    <BaseCard
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                    />
-                                                </div>
-                                            ))}
-                                        </div>
-                                        <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
-                                    </div>
-
-                                    <div className="trade-section">
-                                        <h3>Requested Items</h3>
-                                        <div className="cards-grid">
-                                            {trade.requestedItems?.map((item) => (
-                                                <div key={item._id} className="full-card">
-                                                    <BaseCard
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                    />
-                                                </div>
-                                            ))}
-                                        </div>
-                                        <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
-                                    </div>
-                                </div>
-                            )}
-
-                        </div>
-                    );
-                })}
-                </div>
-            )}
+  const TradeCard = ({ trade, isOutgoing }) => (
+    <div className={`trade-card ${isOutgoing ? 'outgoing' : 'incoming'}`}>
+      <div className="trade-header">
+        <div className="trade-title">
+          {isOutgoing ? 'To' : 'From'}{' '}
+          <span>{isOutgoing ? trade.recipient.username : trade.sender.username}</span>
         </div>
-    );
+        <div className="trade-buttons-inline">
+          {!isOutgoing ? (
+            <>
+              <button className="accept-button" onClick={() => handleAction(trade._id, 'accept')}>
+                Accept
+              </button>
+              <button className="reject-button" onClick={() => handleAction(trade._id, 'reject')}>
+                Reject
+              </button>
+              <button className="counter-button" onClick={() => handleCounter(trade)}>
+                Counter
+              </button>
+            </>
+          ) : (
+            <button className="cancel-button" onClick={() => handleAction(trade._id, 'cancel')}>
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="trade-body">
+        <div className="trade-side">
+          <h3>Offered</h3>
+          <div className="cards-grid">
+            {trade.offeredItems?.map((item) => (
+              <div key={item._id} className="full-card">
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
+              </div>
+            ))}
+          </div>
+          <span className="packs-chip">
+            {trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}
+          </span>
+        </div>
+        <div className="trade-arrow">for</div>
+        <div className="trade-side">
+          <h3>Requested</h3>
+          <div className="cards-grid">
+            {trade.requestedItems?.map((item) => (
+              <div key={item._id} className="full-card">
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
+              </div>
+            ))}
+          </div>
+          <span className="packs-chip">
+            {trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+      <div className="trade-timestamp">
+        Created on: {new Date(trade.createdAt).toLocaleString()}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="pending-trades-container">
+      <h1 className="page-title">Pending Trades</h1>
+
+      <div className="filters">
+        <input
+          type="text"
+          placeholder="Search by username..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="search-box"
+        />
+        <select value={sortOrder} onChange={(e) => setSortOrder(e.target.value)} className="sort-dropdown">
+          <option value="newest">Newest First</option>
+          <option value="oldest">Oldest First</option>
+        </select>
+      </div>
+
+      <div className="pending-section">
+        <h2>Incoming Trades</h2>
+        {incoming.length === 0 ? (
+          <p className="no-trades">No incoming trades.</p>
+        ) : (
+          <div className="trades-list">
+            {incoming.map((t) => (
+              <TradeCard key={t._id} trade={t} isOutgoing={false} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="pending-section">
+        <h2>Outgoing Trades</h2>
+        {outgoing.length === 0 ? (
+          <p className="no-trades">No outgoing trades.</p>
+        ) : (
+          <div className="trades-list">
+            {outgoing.map((t) => (
+              <TradeCard key={t._id} trade={t} isOutgoing={true} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default PendingTrades;

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -15,8 +15,8 @@
     background: var(--surface-dark);
     padding: 2rem 1.5rem;
     border-radius: var(--border-radius);
-    margin: 1rem 0;
-    max-width: 100%;
+    margin: 1rem auto;
+    max-width: 1100px;
     color: var(--text-primary);
     box-sizing: border-box;
 }
@@ -168,12 +168,18 @@
 .packs-chip {
     background: var(--surface-darker);
     border-radius: 12px;
-    padding: 0.15rem 0.5rem;
-    font-size: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
 }
 
 .trade-arrow {
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.5rem;
+    font-size: 1.25rem;
 }
 
     .trade-header span {
@@ -224,7 +230,7 @@
 
 /* Expanded trade details */
 .trade-card {
-    cursor: pointer;
+    cursor: default;
 }
 
 .trade-details {
@@ -236,6 +242,11 @@
 .trade-section h3 {
     margin-bottom: 0.5rem;
     font-size: 1rem;
+}
+
+.trade-side h3 {
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
 }
 
 .cards-grid {
@@ -253,6 +264,26 @@
 .full-card .card-container {
     margin: 0 !important;
     max-width: 100% !important;
+}
+
+/* New layout helpers */
+.pending-section {
+    margin-bottom: 3rem;
+}
+
+.trade-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin-top: 1rem;
+}
+
+.trade-side {
+    flex: 1 1 300px;
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--border-radius);
+    padding: 1rem;
 }
 
 /* Timestamp */
@@ -278,9 +309,12 @@
         align-items: center;
     }
 
-    .trade-overview {
+    .trade-body {
         flex-direction: column;
-        align-items: flex-start;
+    }
+
+    .trade-arrow {
+        margin: 0.5rem 0;
     }
 
     .trade-buttons-inline {


### PR DESCRIPTION
## Summary
- redesign PendingTrades page to show incoming and outgoing trades separately
- display full card details without expandable previews
- adjust pending trades styling for new layout
- tighten page margins and enlarge packs chips

## Testing
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6846ee667d2083309fd17390af3875e7