### PR TITLE
Improve pending trades layout

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -1,280 +1,355 @@
-// src/pages/PendingTrades.js
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { fetchUserProfile, fetchPendingTrades, acceptTrade, rejectTrade, cancelTrade } from '../utils/api';
-import LoadingSpinner from '../components/LoadingSpinner'; // Import the spinner
+import {
+  fetchUserProfile,
+  fetchPendingTrades,
+  acceptTrade,
+  rejectTrade,
+  cancelTrade,
+} from '../utils/api';
+import LoadingSpinner from '../components/LoadingSpinner';
 import BaseCard from '../components/BaseCard';
 import '../styles/PendingTrades.css';
 
 const PendingTrades = () => {
-    const [pendingTrades, setPendingTrades] = useState([]);
-    const [loggedInUser, setLoggedInUser] = useState(null);
-    const [error, setError] = useState(null);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [filter, setFilter] = useState('all');
-    const [sortOrder, setSortOrder] = useState('newest');
-    const [expandedTrade, setExpandedTrade] = useState(null);
-    const navigate = useNavigate();
+  const [trades, setTrades] = useState([]);
+  const [user, setUser] = useState(null);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortOrder, setSortOrder] = useState('newest');
+  const [activeTab, setActiveTab] = useState('incoming');
+  const [showFilters, setShowFilters] = useState(false);
+  const [openTrade, setOpenTrade] = useState(null);
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const navigate = useNavigate();
 
-    useEffect(() => {
-        const loadUserProfile = async () => {
-            try {
-                const profile = await fetchUserProfile();
-                setLoggedInUser(profile);
-                loadPendingTrades(profile._id);
-            } catch (err) {
-                console.error('Failed to fetch user profile:', err.message);
-                setError('Failed to fetch user profile');
-            }
-        };
-        loadUserProfile();
-    }, []);
-
-    const loadPendingTrades = async (userId) => {
-        try {
-            const trades = await fetchPendingTrades(userId);
-            setPendingTrades(trades);
-        } catch (err) {
-            console.error('Failed to fetch pending trades:', err);
-            setError('Failed to load pending trades');
-        }
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const profile = await fetchUserProfile();
+        setUser(profile);
+        const data = await fetchPendingTrades(profile._id);
+        setTrades(data);
+      } catch (err) {
+        console.error('Failed to load trades:', err);
+        setError('Failed to load pending trades');
+      }
     };
+    load();
+  }, []);
 
-    const handleTradeAction = async (tradeId, action, e) => {
-        e.stopPropagation();
-        const confirmationMessage = {
-            accept: 'Are you sure you want to accept this trade?',
-            reject: 'Are you sure you want to reject this trade?',
-            cancel: 'Are you sure you want to cancel this trade?'
-        };
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
-        if (window.confirm(confirmationMessage[action])) {
-            try {
-                if (action === 'accept') await acceptTrade(tradeId, loggedInUser._id);
-                if (action === 'reject') await rejectTrade(tradeId, loggedInUser._id);
-                if (action === 'cancel') await cancelTrade(tradeId, loggedInUser._id);
-                loadPendingTrades(loggedInUser._id);
-            } catch (err) {
-                console.error(`Error ${action}ing trade:`, err);
-                setError(`Failed to ${action} trade`);
-            }
-        }
-    };
-
-    const handleCounterOffer = (trade, e) => {
-        e.stopPropagation();
-        navigate('/trading', {
-            state: {
-                counterOffer: {
-                    tradeId: trade._id,
-                    selectedUser: trade.sender.username,
-                    tradeOffer: trade.requestedItems,
-                    tradeRequest: trade.offeredItems,
-                    offeredPacks: trade.requestedPacks,
-                    requestedPacks: trade.offeredPacks,
-                },
-            },
-        });
-    };
-
-    const handleSearch = (e) => setSearchQuery(e.target.value.toLowerCase());
-    const handleFilterChange = (e) => setFilter(e.target.value);
-    const handleSortChange = (e) => setSortOrder(e.target.value);
-    const toggleTrade = (tradeId) => {
-        setExpandedTrade((prev) => (prev === tradeId ? null : tradeId));
-    };
-
-    const cardPreview = (cards = []) => {
-        const preview = cards.slice(0, 3);
-        return (
-            <div className="preview-cards">
-                {preview.map((item) => (
-                    <div key={item._id} className="trade-preview">
-                        <BaseCard
-                            name={item.name}
-                            image={item.imageUrl}
-                            rarity={item.rarity}
-                            description={item.flavorText}
-                            mintNumber={item.mintNumber}
-                        />
-                    </div>
-                ))}
-                {cards.length > preview.length && (
-                    <span className="thumb-more">+{cards.length - preview.length} more</span>
-                )}
-            </div>
-        );
-    };
-
-
-    const filteredAndSortedTrades = pendingTrades
-        .filter((trade) => {
-            if (trade.status !== 'pending') return false;
-            const isIncoming = trade.recipient._id === loggedInUser._id;
-            const isOutgoing = trade.sender._id === loggedInUser._id;
-            if (filter === 'incoming' && !isIncoming) return false;
-            if (filter === 'outgoing' && !isOutgoing) return false;
-            const otherParty = isIncoming ? trade.sender.username : trade.recipient.username;
-            return otherParty.toLowerCase().includes(searchQuery);
-        })
-        .sort((a, b) => {
-            if (sortOrder === 'newest') return new Date(b.createdAt) - new Date(a.createdAt);
-            return new Date(a.createdAt) - new Date(b.createdAt);
-        });
-
-    if (error) return <div className="error-message">{error}</div>;
-
-    if (!loggedInUser) {
-        // If still loading user data, display the global spinner.
-        return <LoadingSpinner />;
+  const refreshTrades = async () => {
+    if (!user) return;
+    try {
+      const data = await fetchPendingTrades(user._id);
+      setTrades(data);
+    } catch (err) {
+      console.error('Failed to refresh trades:', err);
+      setError('Failed to refresh trades');
     }
+  };
 
-    return (
-        <div className="pending-trades-container">
-            <h1 className="page-title">Pending Trades</h1>
+  const handleAction = async (id, action) => {
+    const messages = {
+      accept: 'Are you sure you want to accept this trade?',
+      reject: 'Are you sure you want to reject this trade?',
+      cancel: 'Are you sure you want to cancel this trade?',
+    };
+    if (!window.confirm(messages[action])) return;
+    try {
+      if (action === 'accept') await acceptTrade(id);
+      if (action === 'reject') await rejectTrade(id);
+      if (action === 'cancel') await cancelTrade(id);
+      refreshTrades();
+    } catch (err) {
+      console.error(`Failed to ${action} trade:`, err);
+      setError(`Failed to ${action} trade`);
+    }
+  };
 
-            <div className="filters">
-                <input
-                    type="text"
-                    placeholder="Search by username..."
-                    value={searchQuery}
-                    onChange={handleSearch}
-                    className="search-box"
-                />
-                <select value={filter} onChange={handleFilterChange} className="filter-dropdown">
-                    <option value="all">All Trades</option>
-                    <option value="incoming">Incoming Trades</option>
-                    <option value="outgoing">Outgoing Trades</option>
-                </select>
-                <select value={sortOrder} onChange={handleSortChange} className="sort-dropdown">
-                    <option value="newest">Newest First</option>
-                    <option value="oldest">Oldest First</option>
-                </select>
-            </div>
+  const handleCounter = (trade) => {
+    navigate('/trading', {
+      state: {
+        counterOffer: {
+          tradeId: trade._id,
+          selectedUser: trade.sender.username,
+          tradeOffer: trade.requestedItems,
+          tradeRequest: trade.offeredItems,
+          offeredPacks: trade.requestedPacks,
+          requestedPacks: trade.offeredPacks,
+        },
+      },
+    });
+  };
 
-            {filteredAndSortedTrades.length === 0 ? (
-                <p className="no-trades">No pending trades.</p>
-            ) : (
-                <div className="trades-list">
-                {filteredAndSortedTrades.map((trade) => {
-                    const isOutgoing = trade.sender._id === loggedInUser._id;
-                    const tradeStatusClass = `trade-card ${isOutgoing ? 'outgoing' : 'incoming'} ${expandedTrade === trade._id ? 'expanded' : 'collapsed'}`;
+  if (error) return <div className="error-message">{error}</div>;
+  if (!user) return <LoadingSpinner />;
 
-                    const offeredItemsCount = trade.offeredItems?.length || 0;
-                    const requestedItemsCount = trade.requestedItems?.length || 0;
-                    const tradeSummary = `${offeredItemsCount} item(s) & ${trade.offeredPacks} pack(s) for ${requestedItemsCount} item(s) & ${trade.requestedPacks} pack(s)`;
+  const pending = trades.filter((t) => t.status === 'pending');
 
-                    return (
-                        <div
-                            key={trade._id}
-                            className={tradeStatusClass}
-                            onClick={() => toggleTrade(trade._id)}
-                        >
-                            <div className="trade-header">
-                                <div className="trade-header-info">
-                                    <div className="trade-title">
-                                        {isOutgoing ? 'Outgoing to' : 'Incoming from'}{' '}
-                                        <span>
-                                            {isOutgoing ? trade.recipient.username : trade.sender.username}
-                                        </span>
-                                    </div>
-                                    <div className="trade-summary">{tradeSummary}</div>
-                                    <div className="trade-overview">
-                                        <div className="overview-section">
-                                            {cardPreview(trade.offeredItems)}
-                                            <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
-                                        </div>
-                                        <div className="trade-arrow">for</div>
-                                        <div className="overview-section">
-                                            {cardPreview(trade.requestedItems)}
-                                            <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="trade-buttons-inline" onClick={(e) => e.stopPropagation()}>
-                                    {!isOutgoing ? (
-                                        <>
-                                            <button
-                                                className="accept-button"
-                                                onClick={(e) => handleTradeAction(trade._id, 'accept', e)}
-                                            >
-                                                Accept
-                                            </button>
-                                            <button
-                                                className="reject-button"
-                                                onClick={(e) => handleTradeAction(trade._id, 'reject', e)}
-                                            >
-                                                Reject
-                                            </button>
-                                            <button
-                                                className="counter-button"
-                                                onClick={(e) => handleCounterOffer(trade, e)}
-                                            >
-                                                Counter
-                                            </button>
-                                        </>
-                                    ) : (
-                                        <button
-                                            className="cancel-button"
-                                            onClick={(e) => handleTradeAction(trade._id, 'cancel', e)}
-                                        >
-                                            Cancel Trade
-                                        </button>
-                                    )}
-                                </div>
-                            </div>
+  const sortFn = (a, b) =>
+    sortOrder === 'newest'
+      ? new Date(b.createdAt) - new Date(a.createdAt)
+      : new Date(a.createdAt) - new Date(b.createdAt);
 
-                            <div className="trade-timestamp">
-                                Created on: {new Date(trade.createdAt).toLocaleString()}
-                            </div>
+  const incoming = pending
+    .filter((t) => t.recipient._id === user._id)
+    .filter((t) =>
+      t.sender.username.toLowerCase().includes(searchQuery.toLowerCase())
+    )
+    .sort(sortFn);
+  const outgoing = pending
+    .filter((t) => t.sender._id === user._id)
+    .filter((t) =>
+      t.recipient.username.toLowerCase().includes(searchQuery.toLowerCase())
+    )
+    .sort(sortFn);
 
-                            {expandedTrade === trade._id && (
-                                <div className="trade-details" onClick={(e) => e.stopPropagation()}>
-                                    <div className="trade-section">
-                                        <h3>Offered Items</h3>
-                                        <div className="cards-grid">
-                                            {trade.offeredItems?.map((item) => (
-                                                <div key={item._id} className="full-card">
-                                                    <BaseCard
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                    />
-                                                </div>
-                                            ))}
-                                        </div>
-                                        <span className="packs-chip">{trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}</span>
-                                    </div>
+  const tradesToShow = activeTab === 'incoming' ? incoming : outgoing;
 
-                                    <div className="trade-section">
-                                        <h3>Requested Items</h3>
-                                        <div className="cards-grid">
-                                            {trade.requestedItems?.map((item) => (
-                                                <div key={item._id} className="full-card">
-                                                    <BaseCard
-                                                        name={item.name}
-                                                        image={item.imageUrl}
-                                                        rarity={item.rarity}
-                                                        description={item.flavorText}
-                                                        mintNumber={item.mintNumber}
-                                                    />
-                                                </div>
-                                            ))}
-                                        </div>
-                                        <span className="packs-chip">{trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}</span>
-                                    </div>
-                                </div>
-                            )}
+  const timeAgo = (date) => {
+    const diff = Math.floor((Date.now() - new Date(date)) / 1000);
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+  };
 
-                        </div>
-                    );
-                })}
-                </div>
-            )}
+  const TradeTile = ({ trade, isOutgoing }) => (
+    <div
+      className="trade-tile"
+      onClick={() => setOpenTrade(trade)}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="tile-header">
+        <div className="avatar">
+          {(isOutgoing ? trade.recipient.username : trade.sender.username)
+            .charAt(0)
+            .toUpperCase()}
         </div>
-    );
+        <div className="tile-info">
+          <div className="tile-user">
+            {isOutgoing ? trade.recipient.username : trade.sender.username}
+          </div>
+          <div className="tile-age">{timeAgo(trade.createdAt)}</div>
+        </div>
+        <span className="status-badge">pending</span>
+      </div>
+      <div className="tile-preview">
+        {trade.offeredItems[0] && (
+          <img src={trade.offeredItems[0].imageUrl} alt="offered" />
+        )}
+        <span className="arrow">→</span>
+        {trade.requestedItems[0] && (
+          <img src={trade.requestedItems[0].imageUrl} alt="requested" />
+        )}
+      </div>
+    </div>
+  );
+
+  const MobileTrade = ({ trade, isOutgoing }) => (
+    <details className="trade-accordion">
+      <summary>
+        <div className="tile-header">
+          <div className="avatar">
+            {(isOutgoing ? trade.recipient.username : trade.sender.username)
+              .charAt(0)
+              .toUpperCase()}
+          </div>
+          <div className="tile-info">
+            <div className="tile-user">
+              {isOutgoing ? trade.recipient.username : trade.sender.username}
+            </div>
+            <div className="tile-age">{timeAgo(trade.createdAt)}</div>
+          </div>
+          <span className="status-badge">pending</span>
+        </div>
+      </summary>
+      <div className="accordion-body">
+        <TradeDetails trade={trade} isOutgoing={isOutgoing} />
+      </div>
+    </details>
+  );
+
+  const TradeDetails = ({ trade, isOutgoing }) => (
+    <div className="trade-details-wrapper">
+      <div className="trade-sides">
+        <div className="trade-side">
+          <h3>Offered</h3>
+          <div className="cards-grid">
+            {trade.offeredItems?.map((item) => (
+              <div key={item._id} className="full-card">
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
+              </div>
+            ))}
+          </div>
+          <span className="packs-chip">
+            {trade.offeredPacks} pack{trade.offeredPacks !== 1 ? 's' : ''}
+          </span>
+        </div>
+        <div className="trade-side">
+          <h3>Requested</h3>
+          <div className="cards-grid">
+            {trade.requestedItems?.map((item) => (
+              <div key={item._id} className="full-card">
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
+              </div>
+            ))}
+          </div>
+          <span className="packs-chip">
+            {trade.requestedPacks} pack{trade.requestedPacks !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+      <div className="trade-actions">
+        {!isOutgoing ? (
+          <>
+            <button
+              className="accept-button"
+              onClick={() => handleAction(trade._id, 'accept')}
+            >
+              Accept
+            </button>
+            <button
+              className="reject-button"
+              onClick={() => handleAction(trade._id, 'reject')}
+            >
+              Reject
+            </button>
+            <button
+              className="counter-button"
+              onClick={() => handleCounter(trade)}
+            >
+              Counter
+            </button>
+          </>
+        ) : (
+          <button
+            className="cancel-button"
+            onClick={() => handleAction(trade._id, 'cancel')}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const TradeModal = ({ trade, isOutgoing }) => (
+    <div className="modal-overlay" onClick={() => setOpenTrade(null)}>
+      <div className="trade-modal" onClick={(e) => e.stopPropagation()}>
+        <button className="modal-close" onClick={() => setOpenTrade(null)}>
+          ✕
+        </button>
+        <TradeDetails trade={trade} isOutgoing={isOutgoing} />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="pending-trades-page">
+      <h1 className="page-title">Pending Trades</h1>
+
+      <div className="trade-tabs">
+        <button
+          className={activeTab === 'incoming' ? 'active' : ''}
+          onClick={() => setActiveTab('incoming')}
+        >
+          Incoming
+        </button>
+        <button
+          className={activeTab === 'outgoing' ? 'active' : ''}
+          onClick={() => setActiveTab('outgoing')}
+        >
+          Outgoing
+        </button>
+      </div>
+
+      <div className="filters-bar">
+        <button
+          className="toggle-filters"
+          onClick={() => setShowFilters((p) => !p)}
+        >
+          Filters
+        </button>
+        {showFilters && (
+          <div className="filters-panel">
+            <input
+              type="text"
+              placeholder="Search by username..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <select
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+            >
+              <option value="newest">Newest First</option>
+              <option value="oldest">Oldest First</option>
+            </select>
+          </div>
+        )}
+      </div>
+
+      {!isMobile && (
+        <div className="trades-grid">
+          {tradesToShow.length === 0 ? (
+            <p className="no-trades">No trades.</p>
+          ) : (
+            tradesToShow.map((t) => (
+              <TradeTile
+                key={t._id}
+                trade={t}
+                isOutgoing={activeTab === 'outgoing'}
+              />
+            ))
+          )}
+        </div>
+      )}
+
+      {isMobile && (
+        <div className="trade-accordions">
+          {tradesToShow.length === 0 ? (
+            <p className="no-trades">No trades.</p>
+          ) : (
+            tradesToShow.map((t) => (
+              <MobileTrade
+                key={t._id}
+                trade={t}
+                isOutgoing={activeTab === 'outgoing'}
+              />
+            ))
+          )}
+        </div>
+      )}
+
+      {openTrade && (
+        <TradeModal
+          trade={openTrade}
+          isOutgoing={openTrade.sender._id === user._id}
+        />
+      )}
+    </div>
+  );
 };
 
 export default PendingTrades;

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -1,289 +1,261 @@
 :root {
-    --brand-primary: #db88db;
-    --brand-secondary: #88cddb;
-    --background-dark: #0a0a0a;
-    --surface-dark: #1a1a1a;
-    --surface-darker: #141414;
-    --text-primary: rgba(255, 255, 255, 0.95);
-    --border-dark: rgba(255, 255, 255, 0.12);
-    --border-radius: 16px;
-    --transition: all 0.3s ease;
+  --brand-primary: #db88db;
+  --brand-secondary: #88cddb;
+  --background-dark: #0a0a0a;
+  --surface-dark: #1a1a1a;
+  --surface-darker: #141414;
+  --text-primary: rgba(255, 255, 255, 0.95);
+  --border-dark: rgba(255, 255, 255, 0.12);
+  --border-radius: 16px;
+  --transition: all 0.3s ease;
 }
 
-/* Main container for the pending trades page */
-.pending-trades-container {
-    background: var(--surface-dark);
-    padding: 2rem 1.5rem;
-    border-radius: var(--border-radius);
-    margin: 1rem 0;
-    max-width: 100%;
-    color: var(--text-primary);
-    box-sizing: border-box;
+.pending-trades-page {
+  margin: 1rem auto;
+  max-width: 1100px;
+  padding: 1rem;
+  color: var(--text-primary);
 }
 
-/* Page Title styled like the Collection page title */
 .page-title {
-    text-align: center;
-    font-size: 2.25rem;
-    font-weight: 500;
-    margin: 1.5rem 0;
-    position: relative;
-    color: var(--text-primary);
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  position: relative;
+}
+.page-title::after {
+  content: '';
+  position: absolute;
+  bottom: -0.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: 2px;
+  background: var(--brand-primary);
 }
 
-    .page-title::after {
-        content: '';
-        position: absolute;
-        bottom: -0.5rem;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 100px;
-        height: 2px;
-        background: var(--brand-primary);
-        border-radius: 2px;
-    }
-
-/* Filters */
-.filters {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-    justify-content: center;
+.trade-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-dark);
+}
+.trade-tabs button {
+  background: none;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.trade-tabs button.active {
+  border-bottom: 3px solid var(--brand-primary);
+  color: #fff;
+  font-weight: bold;
 }
 
-/* Grid layout for trade tiles */
-.trades-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+.filters-bar {
+  position: sticky;
+  top: 60px;
+  background: var(--surface-dark);
+  padding: 0.5rem;
+  z-index: 500;
+  border-bottom: 1px solid var(--border-dark);
+}
+.toggle-filters {
+  background: var(--brand-secondary);
+  color: var(--text-primary);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+}
+.filters-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.filters-panel input,
+.filters-panel select {
+  padding: 0.5rem 0.75rem;
+  background: var(--surface-darker);
+  color: var(--text-primary);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--border-radius);
 }
 
-    .filters input,
-    .filters select {
-        padding: 0.75rem 1rem;
-        border: 1px solid var(--border-dark);
-        border-radius: var(--border-radius);
-        background: var(--surface-dark);
-        color: var(--text-primary);
-        font-size: 1rem;
-        transition: var(--transition);
-    }
-
-        .filters input::placeholder {
-            color: #888;
-        }
-
-/* Trade Card Container */
-.trade-card {
-    background: var(--surface-dark);
-    border-radius: var(--border-radius);
-    padding: 2rem;
-    margin-bottom: 1rem;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    transition: var(--transition);
-    position: relative;
-    width: 100%;
+.trades-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.trade-tile {
+  background: var(--surface-dark);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+.trade-tile:hover {
+  transform: translateY(-2px);
+}
+.tile-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--surface-darker);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+.tile-info {
+  flex: 1;
+  margin-left: 0.5rem;
+}
+.tile-user {
+  font-size: 1rem;
+}
+.tile-age {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+.status-badge {
+  background: var(--brand-primary);
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+}
+.tile-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+.tile-preview img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+.tile-preview .arrow {
+  font-size: 1.25rem;
+  margin: 0 0.25rem;
 }
 
-
-    .trade-card:hover {
-        transform: translateY(-2px);
-    }
-
-    /* Subtle branding accents on trade cards */
-    .trade-card.incoming {
-        border-left: 3px solid var(--brand-primary);
-    }
-
-    .trade-card.outgoing {
-        border-left: 3px solid var(--brand-secondary);
-    }
-
-/* Trade Header: Flex container for info and inline buttons */
-.trade-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 1.5rem;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
+.trade-accordion {
+  background: var(--surface-dark);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+}
+.trade-accordion summary {
+  padding: 1rem;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.trade-accordion summary::-webkit-details-marker { display:none; }
+.accordion-body {
+  padding: 1rem;
 }
 
-.trade-header-info {
-    flex: 1;
+.trade-details-wrapper {
+  width: 100%;
 }
-
-.trade-title {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    font-size: 1.2rem;
-    line-height: 1.2;
+.trade-sides {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
-
-.trade-summary {
-    font-size: 0.9rem;
-    opacity: 0.8;
-    margin-top: 0.25rem;
+.trade-side {
+  flex: 1 1 280px;
+  background: var(--surface-darker);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--border-radius);
+  padding: 1rem;
 }
-
-.trade-overview {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    margin-top: 0.5rem;
-}
-
-.overview-section {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-.preview-cards {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-.trade-preview {
-    width: 150px;
-    max-width: 150px;
-}
-
-.trade-preview .card-container {
-    margin: 0 !important;
-    max-width: 100% !important;
-}
-
-.thumb-more {
-    font-size: 0.8rem;
-    color: #bbb;
-    padding-left: 0.25rem;
-    display: inline-block;
-}
-
-.packs-chip {
-    background: var(--surface-darker);
-    border-radius: 12px;
-    padding: 0.15rem 0.5rem;
-    font-size: 0.75rem;
-}
-
-.trade-arrow {
-    font-weight: 600;
-}
-
-    .trade-header span {
-        font-size: 1rem;
-        color: var(--text-primary);
-    }
-
-/* Inline buttons container inside the trade header */
-.trade-buttons-inline {
-    display: flex;
-    gap: 0.5rem;
-}
-
-    /* Inline trade action buttons styled in line with the rest of the app */
-    .trade-buttons-inline button {
-        background-color: var(--brand-primary);
-        color: var(--text-primary);
-        border: none;
-        border-radius: var(--border-radius);
-        padding: 0.5rem 1rem;
-        font-size: 1rem;
-        font-weight: bold;
-        cursor: pointer;
-        transition: background-color 0.3s ease, transform 0.2s ease;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-    }
-
-    .trade-buttons-inline button:hover {
-        background-color: #722ebf;
-        transform: scale(1.05);
-    }
-
-.accept-button {
-    background-color: #2e7d32;
-}
-
-.reject-button {
-    background-color: #c62828;
-}
-
-.cancel-button {
-    background-color: #616161;
-}
-
-.counter-button {
-    background-color: var(--brand-secondary);
-}
-
-/* Expanded trade details */
-.trade-card {
-    cursor: pointer;
-}
-
-.trade-details {
-    margin-top: 1rem;
-    display: grid;
-    gap: 1rem;
-}
-
-.trade-section h3 {
-    margin-bottom: 0.5rem;
-    font-size: 1rem;
-}
-
 .cards-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
-
 .full-card {
-    width: 300px;
-    max-width: 300px;
+  width: 200px;
+  max-width: 200px;
 }
-
 .full-card .card-container {
-    margin: 0 !important;
-    max-width: 100% !important;
+  margin: 0 !important;
+  max-width: 100% !important;
+}
+.trade-actions {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.trade-actions button {
+  width: 100%;
+  padding: 0.75rem 0;
+  border: none;
+  border-radius: var(--border-radius);
+  font-weight: bold;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+.accept-button { background: #2e7d32; }
+.reject-button { background: #c62828; }
+.cancel-button { background: #616161; }
+.counter-button { background: var(--brand-secondary); }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+.trade-modal {
+  background: var(--surface-dark);
+  padding: 1.5rem;
+  border-radius: var(--border-radius);
+  max-width: 900px;
+  width: 90%;
+  position: relative;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 
-/* Timestamp */
-.trade-timestamp {
-    font-size: 0.9rem;
-    color: #aaa;
-    margin-bottom: 1rem;
-}
-
-/* Error and No Trades Messages */
-.error-message,
-.no-trades {
-    text-align: center;
-    font-size: 1.2rem;
-    margin-top: 1.5rem;
-    color: #f44336;
-}
-
-/* Responsive adjustments */
 @media (max-width: 768px) {
-    .filters {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .trade-overview {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .trade-buttons-inline {
-        margin-top: 0.5rem;
-    }
+  .trades-grid { display: none; }
+  .trade-accordions { display: block; }
+}
+@media (min-width: 769px) {
+  .trade-accordions { display: none; }
 }


### PR DESCRIPTION
## Summary
- redesign PendingTrades page with incoming/outgoing tabs
- add sticky filter bar and responsive trade grid or accordion
- show trade details in modal overlay with full cards
- update styles for new layout

## Testing
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6846ee667d2083309fd17390af3875e7