### PR TITLE
Improve Pending Trades UX

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-icons": "^4.9.0",
         "react-modal": "^3.16.3",
         "react-router-dom": "^7.1.1",
+        "react-window": "^1.8.7",
         "react-scripts": "5.0.1",
         "socket.io-client": "^4.8.1",
         "three": "^0.172.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react-icons": "^4.9.0",
     "react-modal": "^3.16.3",
     "react-router-dom": "^7.1.1",
+    "react-window": "^1.8.7",
     "react-scripts": "5.0.1",
     "socket.io-client": "^4.8.1",
     "three": "^0.172.0",

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -235,6 +235,7 @@ const BaseCard = ({
                     alt={name}
                     className="grayscale"
                     draggable={false}
+                    loading="lazy"
                   />
                   <img
                     src={image}
@@ -242,10 +243,11 @@ const BaseCard = ({
                     className="invertband"
                     ref={invertRef}
                     draggable={false}
+                    loading="lazy"
                   />
                 </>
               ) : (
-                <img src={image} alt={name} draggable={false} />
+                <img src={image} alt={name} draggable={false} loading="lazy" />
               )}
 
               {modifierData?.name === 'Rainbow Holo' && (

--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useRef, useState } from 'react';
+import { FixedSizeGrid as Grid } from 'react-window';
 import { useNavigate } from 'react-router-dom';
 import {
   fetchUserProfile,
@@ -33,6 +34,8 @@ const PendingTrades = () => {
   const [openTrade, setOpenTrade] = useState(null);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const sidebarRef = useRef(null);
+  const gridRef = useRef(null);
+  const [gridWidth, setGridWidth] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -54,6 +57,13 @@ const PendingTrades = () => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    const updateWidth = () => setGridWidth(gridRef.current?.offsetWidth || 0);
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
   }, []);
 
   useEffect(() => {
@@ -168,11 +178,11 @@ const PendingTrades = () => {
       </header>
       <div className="preview">
         {trade.offeredItems[0] && (
-          <img src={trade.offeredItems[0].imageUrl} alt="offered" />
+          <img src={trade.offeredItems[0].imageUrl} alt="offered" loading="lazy" />
         )}
         <span className="arrow">→</span>
         {trade.requestedItems[0] && (
-          <img src={trade.requestedItems[0].imageUrl} alt="requested" />
+          <img src={trade.requestedItems[0].imageUrl} alt="requested" loading="lazy" />
         )}
       </div>
       <footer className="card-foot">{timeAgo(trade.createdAt)}</footer>
@@ -501,9 +511,36 @@ const PendingTrades = () => {
           role="tabpanel"
           id={activeTab === 'incoming' ? 'panel-in' : 'panel-out'}
           aria-labelledby={activeTab === 'incoming' ? 'tab-in' : 'tab-out'}
+          ref={gridRef}
         >
           {tradesToShow.length === 0 ? (
             <p className="no-trades">No trades.</p>
+          ) : tradesToShow.length > 20 ? (
+            <Grid
+              columnCount={Math.max(1, Math.floor(gridWidth / 264))}
+              columnWidth={264}
+              height={600}
+              rowCount={Math.ceil(
+                tradesToShow.length / Math.max(1, Math.floor(gridWidth / 264))
+              )}
+              rowHeight={360}
+              width={gridWidth}
+            >
+              {({ columnIndex, rowIndex, style }) => {
+                const colCount = Math.max(1, Math.floor(gridWidth / 264));
+                const index = rowIndex * colCount + columnIndex;
+                const trade = tradesToShow[index];
+                if (!trade) return null;
+                return (
+                  <div style={{ ...style, padding: 12 }}>
+                    <TradeTile
+                      trade={trade}
+                      isOutgoing={activeTab === 'outgoing'}
+                    />
+                  </div>
+                );
+              }}
+            </Grid>
           ) : (
             tradesToShow.map((t) => (
               <TradeTile

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -1,7 +1,7 @@
 :root {
-  --brand-primary: #db88db;
+  --brand-primary: #8c52ff;
   --brand-secondary: #88cddb;
-  --background-dark: #0a0a0a;
+  --background-dark: #0e0e0e;
   --surface-dark: #1a1a1a;
   --surface-darker: #141414;
   --text-primary: rgba(255, 255, 255, 0.95);
@@ -70,7 +70,9 @@
   padding: 0.5rem 1rem;
   color: var(--text-primary);
   cursor: pointer;
+  transition: filter 0.2s ease;
 }
+.open-filters:hover { filter: brightness(90%); }
 
 .filters-overlay {
   position: fixed;
@@ -94,8 +96,14 @@
   flex-direction: column;
   gap: 0.75rem;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.5);
-  transform: translateX(0);
+  transform: translateX(100%);
+  animation: slide-in 0.2s ease forwards;
   z-index: 20;
+}
+
+@keyframes slide-in {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
 }
 .filters-sidebar input,
 .filters-sidebar select {
@@ -112,7 +120,9 @@
   color: var(--text-primary);
   font-size: 1.25rem;
   cursor: pointer;
+  transition: filter 0.2s ease;
 }
+.close-filters:hover { filter: brightness(90%); }
 
 .trades-grid {
   display: grid;
@@ -126,10 +136,11 @@
   border-radius: var(--border-radius);
   padding: 1rem;
   cursor: pointer;
-  transition: box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease, filter 0.2s ease;
 }
 .trade-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  filter: brightness(90%);
 }
 .trade-card:focus {
   outline: 2px dashed var(--brand-primary);
@@ -266,11 +277,18 @@
   font-weight: bold;
   cursor: pointer;
   color: var(--text-primary);
+  transition: filter 0.2s ease, transform 0.1s ease;
 }
-.accept-button { background: #2e7d32; }
-.reject-button { background: #c62828; }
+.trade-actions button:hover {
+  filter: brightness(90%);
+}
+.trade-actions button:active {
+  transform: scale(0.97);
+}
+.accept-button { background: #3cb043; }
+.reject-button { background: #e53e3e; }
 .cancel-button { background: #616161; }
-.counter-button { background: var(--brand-secondary); }
+.counter-button { background: #5bc0de; }
 
 .modal-overlay {
   position: fixed;
@@ -283,6 +301,7 @@
   justify-content: center;
   align-items: center;
   z-index: 1000;
+  animation: fade-in 0.2s ease forwards;
 }
 .trade-modal {
   background: var(--surface-dark);
@@ -293,6 +312,8 @@
   position: relative;
   max-height: 90vh;
   overflow-y: auto;
+  transform: scale(0.9);
+  animation: pop 0.2s ease forwards;
 }
 
 .modal-head {
@@ -336,6 +357,22 @@
   height: 40px;
   border-radius: 8px;
 
+}
+
+@media (max-width: 768px) {
+  .modal-actions {
+    flex-direction: column;
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pop {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- tweak PendingTrades styles for darker theme and micro‑interactions
- add opening animations for sidebar and modal
- load card images lazily
- virtualize long trade lists with `react-window`
- include `react-window` dependency

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472d4dc8048330a96efecaf88ccb65