### PR TITLE
Improve pending trades view

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -11,6 +11,19 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import BaseCard from '../components/BaseCard';
 import '../styles/PendingTrades.css';
 
+const rarityColors = {
+  Basic: '#8D8D8D',
+  Common: '#64B5F6',
+  Standard: '#66BB6A',
+  Uncommon: '#1976D2',
+  Rare: '#AB47BC',
+  Epic: '#FFA726',
+  Legendary: '#e32232',
+  Mythic: 'hotpink',
+  Unique: 'black',
+  Divine: 'white',
+};
+
 const PendingTrades = () => {
   const [trades, setTrades] = useState([]);
   const [user, setUser] = useState(null);
@@ -87,6 +100,20 @@ const PendingTrades = () => {
     return `${Math.floor(diff / 86400)}d`;
   };
 
+  const offerSummary = (items, packs) => {
+    if (items.length === 0) return packs > 0 ? `${packs} packs` : '';
+    const first = items[0];
+    const extras = items.length - 1;
+    const rarityColor = rarityColors[first.rarity] || 'inherit';
+    return (
+      <span>
+        {first.name} <span style={{ color: rarityColor }}>{first.rarity}</span>
+        {extras > 0 && ` +${extras} more`}
+        {packs > 0 && ` + ${packs} packs`}
+      </span>
+    );
+  };
+
   const sortFn = (a, b) => new Date(b.createdAt) - new Date(a.createdAt);
 
   const incoming = trades
@@ -117,37 +144,32 @@ const PendingTrades = () => {
   );
 
   const TradeRow = ({ trade, isOutgoing }) => (
-    <tr tabIndex={0} onClick={() => setOpenTrade(trade)}>
+    <tr
+      tabIndex={0}
+      onClick={() =>
+        setOpenTrade(openTrade && openTrade._id === trade._id ? null : trade)
+      }
+    >
       <td><RowActions trade={trade} isOutgoing={isOutgoing} /></td>
       <td className="who">
         <strong>{isOutgoing ? 'you' : trade.sender.username}</strong>
         <span className="arrow">→</span>
         <strong>{isOutgoing ? trade.recipient.username : 'you'}</strong>
       </td>
-      <td>
-        {trade.offeredItems.slice(0,3).map((i) => (
-          <img key={i._id} src={i.imageUrl} alt={i.name} />
-        ))}
-        {trade.offeredItems.length > 3 && (
-          <span className="badge">+{trade.offeredItems.length - 3}</span>
-        )}
-        {trade.offeredPacks > 0 && <span className="packs">📦{trade.offeredPacks}</span>}
-      </td>
-      <td>
-        {trade.requestedItems.slice(0,3).map((i) => (
-          <img key={i._id} src={i.imageUrl} alt={i.name} />
-        ))}
-        {trade.requestedItems.length > 3 && (
-          <span className="badge">+{trade.requestedItems.length - 3}</span>
-        )}
-        {trade.requestedPacks > 0 && <span className="packs">📦{trade.requestedPacks}</span>}
-      </td>
+      <td>{offerSummary(trade.offeredItems, trade.offeredPacks)}</td>
+      <td>{offerSummary(trade.requestedItems, trade.requestedPacks)}</td>
       <td className="age">{timeAgo(trade.createdAt)}</td>
     </tr>
   );
 
   const MobileCard = ({ trade, isOutgoing }) => (
-    <div className="mobile-card" tabIndex={0} onClick={() => setOpenTrade(trade)}>
+    <div
+      className="mobile-card"
+      tabIndex={0}
+      onClick={() =>
+        setOpenTrade(openTrade && openTrade._id === trade._id ? null : trade)
+      }
+    >
       <div className="top">
         <span>
           {isOutgoing ? 'you' : trade.sender.username} →{' '}
@@ -156,13 +178,9 @@ const PendingTrades = () => {
         <span className="age">{timeAgo(trade.createdAt)}</span>
       </div>
       <div className="preview">
-        {trade.offeredItems.slice(0,3).map((i) => (
-          <img key={i._id} src={i.imageUrl} alt={i.name} />
-        ))}
+        {offerSummary(trade.offeredItems, trade.offeredPacks)}
         <span className="arrow">→</span>
-        {trade.requestedItems.slice(0,3).map((i) => (
-          <img key={i._id} src={i.imageUrl} alt={i.name} />
-        ))}
+        {offerSummary(trade.requestedItems, trade.requestedPacks)}
       </div>
       <div className="actions">
         <RowActions trade={trade} isOutgoing={isOutgoing} />

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -186,7 +186,7 @@ body {
   position: fixed;
   top: 0;
   right: 0;
-  width: 360px;
+  width: 480px;
   max-width: 100%;
   height: 100%;
   background: var(--surface);
@@ -218,13 +218,17 @@ body {
   overflow-y: auto;
 }
 .card-grid {
+  --card-scale: 0.4;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px,1fr));
+  grid-template-columns: repeat(auto-fit, minmax(calc(300px * var(--card-scale)), 1fr));
   gap: 16px;
+  justify-items: center;
 }
 .card-tile {
-  width: 120px;
-
+  width: calc(100% / var(--card-scale));
+  max-width: 300px;
+  transform: scale(var(--card-scale));
+  transform-origin: top left;
 }
 .pack-tile {
   background: #282828;
@@ -248,13 +252,8 @@ body {
   .mobile-card .preview {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
     margin: 8px 0;
-  }
-  .mobile-card .preview img {
-    width: 40px;
-    height: 40px;
-    border-radius: var(--radius-sm);
   }
   .mobile-card .top {
     display: flex;


### PR DESCRIPTION
## Summary
- make the sidebar wider
- allow closing sidebar by clicking the row again
- show trade summaries with colored rarity text
- scale cards using `--card-scale` like collection page
- tweak mobile preview style

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_6848420dd57c8330aaa69d47679e4c58