### PR TITLE
Enhance pending trade panel

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -31,7 +31,14 @@ const PendingTrades = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState('incoming');
   const [openTrade, setOpenTrade] = useState(null);
+  const [panelOpen, setPanelOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  useEffect(() => {
+    if (!panelOpen && openTrade) {
+      const t = setTimeout(() => setOpenTrade(null), 300);
+      return () => clearTimeout(t);
+    }
+  }, [panelOpen, openTrade]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -143,12 +150,25 @@ const PendingTrades = () => {
     </div>
   );
 
+  const handleRowClick = (trade) => {
+    if (openTrade && openTrade._id === trade._id) {
+      setPanelOpen(false);
+    } else {
+      setPanelOpen(false);
+      setOpenTrade(trade);
+    }
+  };
+
+  useEffect(() => {
+    if (openTrade) {
+      requestAnimationFrame(() => setPanelOpen(true));
+    }
+  }, [openTrade]);
+
   const TradeRow = ({ trade, isOutgoing }) => (
     <tr
       tabIndex={0}
-      onClick={() =>
-        setOpenTrade(openTrade && openTrade._id === trade._id ? null : trade)
-      }
+      onClick={() => handleRowClick(trade)}
     >
       <td><RowActions trade={trade} isOutgoing={isOutgoing} /></td>
       <td className="who">
@@ -166,9 +186,7 @@ const PendingTrades = () => {
     <div
       className="mobile-card"
       tabIndex={0}
-      onClick={() =>
-        setOpenTrade(openTrade && openTrade._id === trade._id ? null : trade)
-      }
+      onClick={() => handleRowClick(trade)}
     >
       <div className="top">
         <span>
@@ -188,12 +206,13 @@ const PendingTrades = () => {
     </div>
   );
 
-  const DetailPanel = ({ trade, isOutgoing }) => (
-    <aside className="detail-panel" role="dialog" aria-modal="true">
+  const DetailPanel = ({ trade, isOutgoing, open }) => (
+    <aside className={`detail-panel${open ? ' open' : ''}`} role="dialog" aria-modal="true">
       <header>
         <h2>Trade Details</h2>
-        <button onClick={() => setOpenTrade(null)} aria-label="Close details">✕</button>
+        <button onClick={() => setPanelOpen(false)} aria-label="Close details">✕</button>
       </header>
+      <button className="close-button" onClick={() => setPanelOpen(false)} aria-label="Close panel">✕</button>
       <div className="detail-body">
         <section>
           <h3>Offered</h3>
@@ -265,7 +284,11 @@ const PendingTrades = () => {
         )}
       </div>
       {openTrade && (
-        <DetailPanel trade={openTrade} isOutgoing={openTrade.sender._id === user._id} />
+        <DetailPanel
+          trade={openTrade}
+          isOutgoing={openTrade.sender._id === user._id}
+          open={panelOpen}
+        />
       )}
     </div>
   );

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -184,11 +184,11 @@ body {
 
 .detail-panel {
   position: fixed;
-  top: 0;
+  top: 60px;
   right: 0;
-  width: 480px;
+  width: 648px;
   max-width: 100%;
-  height: 100%;
+  height: calc(100% - 60px);
   background: var(--surface);
   box-shadow: var(--shadow);
   padding: 16px;
@@ -196,6 +196,21 @@ body {
   flex-direction: column;
   gap: 16px;
   z-index: 20;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+}
+.detail-panel.open {
+  transform: translateX(0);
+}
+.detail-panel .close-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 20px;
+  cursor: pointer;
 }
 .detail-panel header {
   display: flex;
@@ -223,6 +238,14 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(calc(300px * var(--card-scale)), 1fr));
   gap: 16px;
   justify-items: center;
+}
+
+@media (max-width: 600px) {
+  .card-grid { --card-scale: 0.65; }
+}
+
+@media (max-width: 400px) {
+  .card-grid { --card-scale: 0.55; }
 }
 .card-tile {
   width: calc(100% / var(--card-scale));


### PR DESCRIPTION
## Summary
- refine open/close logic for sliding trade panel
- adjust panel positioning below the navbar
- tweak card grid scale for smaller screens

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684849e843348330842ee0c74e184434