### PR TITLE
Fix card scaling on market pages

### DIFF
--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -23,6 +23,12 @@ const MarketListingDetails = () => {
     const { id } = useParams();
     const navigate = useNavigate();
 
+    const defaultCardScale = 1;
+    const [cardScale] = useState(() => {
+        const storedScale = localStorage.getItem('cardScale');
+        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
+    });
+
     const [listing, setListing] = useState(null);
     const [loading, setLoading] = useState(true);
 
@@ -273,7 +279,7 @@ const MarketListingDetails = () => {
                                     ))}
                                 </select>
                             </div>
-                            <div className="market-user-collection-grid">
+                            <div className="market-user-collection-grid" style={{ '--card-scale': cardScale }}>
                                 {filteredCollection.map((card) => {
                                     const isSelected = selectedOfferedCards.some(c => c._id === card._id);
                                     return (
@@ -297,7 +303,7 @@ const MarketListingDetails = () => {
 
                         <div className="market-selected-cards-panel">
                             <h3>Selected Cards for Offer</h3>
-                            <div className="market-selected-cards-grid">
+                            <div className="market-selected-cards-grid" style={{ '--card-scale': cardScale }}>
                                 {selectedOfferedCards.length > 0 ? (
                                     selectedOfferedCards.map((card) => (
                                         <div key={card._id} className="market-card-wrapper">
@@ -338,7 +344,7 @@ const MarketListingDetails = () => {
                             {offer.offeredCards && offer.offeredCards.length > 0 && (
                                 <div className="offered-cards">
                                     <strong>Offered Cards:</strong>
-                                    <div className="offered-cards-grid">
+                                    <div className="offered-cards-grid" style={{ '--card-scale': cardScale }}>
                                         {offer.offeredCards.map(card => (
                                             <div key={card._id || card.name} className="offered-card-item">
                                                 <BaseCard

--- a/frontend/src/pages/MarketPage.js
+++ b/frontend/src/pages/MarketPage.js
@@ -9,6 +9,11 @@ import '../styles/MarketPage.css';
 import { io } from 'socket.io-client';
 
 const MarketPage = () => {
+    const defaultCardScale = 1;
+    const [cardScale] = useState(() => {
+        const storedScale = localStorage.getItem('cardScale');
+        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
+    });
     const [listings, setListings] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -133,7 +138,7 @@ const MarketPage = () => {
                     <button className="create-listing-button">Create New Listing</button>
                 </Link>
             </div>
-            <div className="listings-grid">
+            <div className="listings-grid" style={{ '--card-scale': cardScale }}>
                 {sortedListings.length > 0 ? (
                     sortedListings.map((listing) => (
                         <div key={listing._id} className="listing-card">

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -115,7 +115,7 @@
 
 /* User Collection Grid */
 .market-user-collection-grid {
-    --listing-card-scale: 1;
+    --card-scale: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -123,8 +123,8 @@
     max-height: 800px;
     overflow-y: auto;
     padding-right: 0.5rem;
-    width: calc(100% / var(--listing-card-scale));
-    transform: scale(var(--listing-card-scale));
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
     transform-origin: top left;
 }
 
@@ -152,7 +152,7 @@
     }
 
 .market-selected-cards-grid {
-    --listing-card-scale: 1;
+    --card-scale: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -160,8 +160,8 @@
     max-height: 800px; /* Increased height for selected cards panel */
     overflow-y: auto;
     padding-right: 0.5rem;
-    width: calc(100% / var(--listing-card-scale));
-    transform: scale(var(--listing-card-scale));
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
     transform-origin: top left;
 }
 
@@ -219,13 +219,13 @@
 }
 
 .offered-cards-grid {
-    --listing-card-scale: 1;
+    --card-scale: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
     margin-top: 0.5rem;
-    width: calc(100% / var(--listing-card-scale));
-    transform: scale(var(--listing-card-scale));
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
     transform-origin: top left;
 }
 
@@ -243,6 +243,6 @@
     .market-user-collection-grid,
     .market-selected-cards-grid,
     .offered-cards-grid {
-        --listing-card-scale: 0.8;
+        --card-scale: 0.8;
     }
 }

--- a/frontend/src/styles/MarketPage.css
+++ b/frontend/src/styles/MarketPage.css
@@ -78,13 +78,13 @@
     }
 
 .listings-grid {
-    --listing-card-scale: 1;
+    --card-scale: 1;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 2rem;
     margin-bottom: 3rem;
-    width: calc(100% / var(--listing-card-scale));
-    transform: scale(var(--listing-card-scale));
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
     transform-origin: top left;
 }
 
@@ -168,6 +168,6 @@
 
 @media (max-width: 600px) {
     .listings-grid {
-        --listing-card-scale: 0.71;
+        --card-scale: 0.71;
     }
 }


### PR DESCRIPTION
## Summary
- read `cardScale` setting from `localStorage` on market pages
- apply `--card-scale` style variable so card size matches collection setting
- rename CSS variable in Market pages for responsive scale
- remove duplicate `--listing-card-scale` usages

## Testing
- `npm test` (fails: no tests)
- `npm test -- -w=0` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_68486a1487b48330837cac6570f66678