### PR TITLE
Fix market page card sizing

### DIFF
--- a/frontend/src/styles/MarketPage.css
+++ b/frontend/src/styles/MarketPage.css
@@ -80,7 +80,7 @@
 .listings-grid {
     --card-scale: 1;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(348px, 1fr));
     gap: 2rem;
     margin-bottom: 3rem;
     width: calc(100% / var(--card-scale));
@@ -98,8 +98,8 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    flex: 1 1 320px;
-    max-width: 320px;
+    flex: 1 1 348px;
+    max-width: 348px;
 }
 
 .listing-card:hover {


### PR DESCRIPTION
## Summary
- ensure market page cards maintain 300px x 450px dimensions at scale
- adjust listings grid column size and listing card width to reflect card-scale variable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(shows "no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68493f6c85048330ae2e555e1b172bad