### PR TITLE
Make channel points cost configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ PORT=5000
 MONGO_URI=
 CLIENT_URL=
 FRONTEND_URL=
+CHANNEL_POINTS_COST=5000
 ```
 
 ### Frontend (`frontend/.env`)
@@ -39,6 +40,7 @@ The frontend uses a small `.env` file:
 ```
 PORT=3000
 REACT_APP_API_BASE_URL=
+REACT_APP_CHANNEL_POINTS_COST=5000
 ```
 
 ## Development Scripts

--- a/backend/.env
+++ b/backend/.env
@@ -9,3 +9,4 @@ PORT=5000
 MONGO_URI=mongodb+srv://jobybarnes1:Qazwsx4321!@cluster0.lrqb8.mongodb.net/
 CLIENT_URL=https://neds-decks.netlify.app
 FRONTEND_URL=https://neds-decks.netlify.app
+CHANNEL_POINTS_COST=5000

--- a/backend/src/routes/twitchRoutes.js
+++ b/backend/src/routes/twitchRoutes.js
@@ -11,6 +11,7 @@ const TWITCH_SECRET = process.env.TWITCH_SECRET;
 const TWITCH_CLIENT_ID = process.env.TWITCH_CLIENT_ID;
 const TWITCH_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET;
 let TWITCH_REFRESH_TOKEN = process.env.TWITCH_REFRESH_TOKEN;
+const CHANNEL_POINTS_COST = parseInt(process.env.CHANNEL_POINTS_COST || '5000', 10);
 
 if (!TWITCH_SECRET) {
     console.error('TWITCH_SECRET is not defined in the environment variables!');
@@ -98,7 +99,7 @@ const handleTwitchEvent = async (event) => {
                 if (
                     reward &&
                     reward.title === "Get A Ned's Decks Pack" &&
-                    reward.cost === 10000
+                    reward.cost === CHANNEL_POINTS_COST
                 ) {
                     console.log(`Processing channel points redemption for ${user_name}`);
                     const existingUser = await User.findOne({ twitchId: user_id });

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 PORT=3000
 REACT_APP_API_BASE_URL=https://neds-decks.onrender.com
+REACT_APP_CHANNEL_POINTS_COST=5000

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -4,6 +4,11 @@ import { fetchUserProfile, fetchMyPacks } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner'; // Import your spinner
 import '../styles/DashboardPage.css';
 
+const CHANNEL_POINTS_COST = parseInt(
+    process.env.REACT_APP_CHANNEL_POINTS_COST || '5000',
+    10
+);
+
 const DashboardPage = () => {
     const [userData, setUserData] = useState(null);
     const [packCount, setPackCount] = useState(0);
@@ -66,7 +71,11 @@ const DashboardPage = () => {
                             <li>Earn 1 pack for your first login and signing into the app.</li>
                             <li>Earn 1 pack every time you subscribe to the show.</li>
                             <li>Earn 1 pack per gifted subscription to the show (e.g., 5 gifted earns 5 packs).</li>
-                            <li>Earn 1 pack by redeeming 10,000 channel points.</li>
+                            <li>
+                                Earn 1 pack by redeeming{' '}
+                                {CHANNEL_POINTS_COST.toLocaleString()} channel
+                                points.
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- make channel points reward cost configurable via `CHANNEL_POINTS_COST`
- display reward cost dynamically on the dashboard
- document new variables in README
- default cost per pack is now set to 5000

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test --silent` in frontend (fails to run react-scripts)


------
https://chatgpt.com/codex/tasks/task_e_68497d9c25948330a47071e12e25a757