### PR TITLE
Update pack rewards on dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -69,8 +69,14 @@ const DashboardPage = () => {
                         <h3>How to Earn Packs:</h3>
                         <ul>
                             <li>Earn 1 pack for your first login and signing into the app.</li>
-                            <li>Earn 1 pack every time you subscribe to the show.</li>
-                            <li>Earn 1 pack per gifted subscription to the show (e.g., 5 gifted earns 5 packs).</li>
+                            <li>
+                                Earn packs when you subscribe: 1 pack for tier 1,
+                                5 packs for tier 2, and 20 packs for tier 3.
+                            </li>
+                            <li>
+                                Gifted subscriptions award packs to the gifter and
+                                each recipient based on the same tier values.
+                            </li>
                             <li>
                                 Earn 1 pack by redeeming{' '}
                                 {CHANNEL_POINTS_COST.toLocaleString()} channel


### PR DESCRIPTION
## Summary
- clarify earning packs on the dashboard page

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5c1e3188330bafb749d2242257c