### PR TITLE
Adjust tier 3 sub reward

### DIFF
--- a/backend/src/routes/twitchRoutes.js
+++ b/backend/src/routes/twitchRoutes.js
@@ -13,7 +13,9 @@ const TWITCH_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET;
 let TWITCH_REFRESH_TOKEN = process.env.TWITCH_REFRESH_TOKEN;
 const CHANNEL_POINTS_COST = parseInt(process.env.CHANNEL_POINTS_COST || '5000', 10);
 // Packs awarded for each subscription tier
-const tierPacks = { '1000': 1, '2000': 5, '3000': 20 };
+// Tier 3 subscriptions were previously awarded 20 packs, which was overly
+// generous. Both regular and gifted tier 3 subs now grant 5 packs instead.
+const tierPacks = { '1000': 1, '2000': 5, '3000': 5 };
 
 if (!TWITCH_SECRET) {
     console.error('TWITCH_SECRET is not defined in the environment variables!');

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -71,7 +71,7 @@ const DashboardPage = () => {
                             <li>Earn 1 pack for your first login and signing into the app.</li>
                             <li>
                                 Earn packs when you subscribe: 1 pack for tier 1,
-                                5 packs for tier 2, and 20 packs for tier 3.
+                                5 packs for tier 2, and 5 packs for tier 3.
                             </li>
                             <li>
                                 Gifted subscriptions award packs to the gifter and


### PR DESCRIPTION
## Summary
- tweak tier3 subscription pack rewards
- update dashboard text about tier rewards

## Testing
- `npm test` (fails: no test specified)
- `npm test --silent` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_684f34bcef2083308985f186a330fba2