### PR TITLE
Improve trade detail panel layout

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -210,30 +210,45 @@ const navigate = useNavigate();
     <aside className={`detail-panel${open ? ' open' : ''}`} role="dialog" aria-modal="true">
       <header>
         <h2>Trade Details</h2>
-        <button onClick={() => setPanelOpen(false)} aria-label="Close details">✕</button>
       </header>
       <button className="close-button" onClick={() => setPanelOpen(false)} aria-label="Close panel">✕</button>
       <div className="detail-body">
         <section>
           <h3>Offered</h3>
+          {trade.offeredPacks > 0 && (
+            <p className="pack-count">{trade.offeredPacks} packs</p>
+          )}
           <div className="card-grid">
             {trade.offeredItems.map((item) => (
               <div key={item._id} className="card-tile">
-                <BaseCard name={item.name} image={item.imageUrl} rarity={item.rarity} description={item.flavorText} mintNumber={item.mintNumber} />
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
               </div>
             ))}
-            {trade.offeredPacks > 0 && <div className="pack-tile">📦 {trade.offeredPacks} packs</div>}
           </div>
         </section>
         <section>
           <h3>Requested</h3>
+          {trade.requestedPacks > 0 && (
+            <p className="pack-count">{trade.requestedPacks} packs</p>
+          )}
           <div className="card-grid">
             {trade.requestedItems.map((item) => (
               <div key={item._id} className="card-tile">
-                <BaseCard name={item.name} image={item.imageUrl} rarity={item.rarity} description={item.flavorText} mintNumber={item.mintNumber} />
+                <BaseCard
+                  name={item.name}
+                  image={item.imageUrl}
+                  rarity={item.rarity}
+                  description={item.flavorText}
+                  mintNumber={item.mintNumber}
+                />
               </div>
             ))}
-            {trade.requestedPacks > 0 && <div className="pack-tile">📦 {trade.requestedPacks} packs</div>}
           </div>
         </section>
       </div>

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -169,6 +169,14 @@ body {
   margin-right: 8px;
   cursor: pointer;
 }
+.detail-panel footer .row-actions {
+  width: 100%;
+}
+.detail-panel footer .row-actions button {
+  flex: 1;
+  padding: 12px 0;
+  font-size: 16px;
+}
 .row-actions button:hover { filter: brightness(1.1); }
 
 .who {
@@ -233,19 +241,25 @@ body {
   overflow-y: auto;
 }
 .card-grid {
-  --card-scale: 0.8;
+  --card-scale: 0.7;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(calc(300px * var(--card-scale)), 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 16px;
   justify-items: center;
 }
 
 @media (max-width: 600px) {
-  .card-grid { --card-scale: 0.65; }
+  .card-grid {
+    --card-scale: 0.65;
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 400px) {
-  .card-grid { --card-scale: 0.55; }
+  .card-grid {
+    --card-scale: 0.55;
+    grid-template-columns: 1fr;
+  }
 }
 .card-tile {
   width: calc(100% / var(--card-scale));
@@ -253,11 +267,10 @@ body {
   transform: scale(var(--card-scale));
   transform-origin: top left;
 }
-.pack-tile {
-  background: #282828;
-  padding: 8px;
-  border-radius: var(--radius-sm);
-  text-align: center;
+.pack-count {
+  margin-bottom: 8px;
+  font-style: italic;
+  color: var(--text-muted);
 }
 .detail-panel footer {
   display: flex;


### PR DESCRIPTION
## Summary
- clean up trade detail header cross button
- show pack counts inline and support up to three cards per row
- enlarge trade action buttons in detail panel

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3cfc73f0833088bfce66d56df9e7