### PR TITLE
Add tool to give packs to all users

### DIFF
--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -45,6 +45,22 @@ router.post('/set-packs', protect, adminOnly, async (req, res) => {
     }
 });
 
+// API to add a specific number of packs to all users
+router.post('/add-packs', protect, adminOnly, async (req, res) => {
+    const { amount } = req.body;
+    const num = Number(amount);
+    if (isNaN(num)) {
+        return res.status(400).json({ error: 'Amount must be a number.' });
+    }
+    try {
+        const result = await User.updateMany({}, { $inc: { packs: num } });
+        res.json({ message: `Added ${num} packs to all users.`, updatedCount: result.modifiedCount });
+    } catch (error) {
+        console.error('Error adding packs to all users:', error);
+        res.status(500).json({ error: 'Failed to add packs to all users.' });
+    }
+});
+
 // New endpoint: Broadcast custom notification to all users
 router.post('/notifications', protect, adminOnly, async (req, res) => {
     const { type, message, link = "" } = req.body; // Allow optional link

--- a/frontend/src/pages/AdminActions.js
+++ b/frontend/src/pages/AdminActions.js
@@ -30,6 +30,7 @@ const AdminActions = () => {
     const [users, setUsers] = useState([]);
     const [selectedUser, setSelectedUser] = useState('');
     const [packAmount, setPackAmount] = useState('');
+    const [addAllAmount, setAddAllAmount] = useState('');
     const [isUserDropdownVisible, setUserDropdownVisible] = useState(false);
     // Card Search Tool state
     const [cardSearchQuery, setCardSearchQuery] = useState('');
@@ -112,6 +113,20 @@ const AdminActions = () => {
             setPackAmount('');
         } catch {
             setStatus('Error giving packs.');
+        }
+    };
+
+    const handleAddPacksAll = async () => {
+        try {
+            await fetchWithAuth('/api/admin/add-packs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ amount: Number(addAllAmount) }),
+            });
+            setStatus(`Added ${addAllAmount} packs to all users.`);
+            setAddAllAmount('');
+        } catch {
+            setStatus('Error adding packs to all users.');
         }
     };
 
@@ -406,8 +421,20 @@ const AdminActions = () => {
                                 required
                             />
                         </div>
+                        <div className="aa-form-group">
+                            <label>Add Packs to All:</label>
+                            <input
+                                type="number"
+                                min="1"
+                                value={addAllAmount}
+                                onChange={e => setAddAllAmount(e.target.value)}
+                            />
+                        </div>
                         <button type="submit" disabled={loading}>
                             {loading ? 'Giving...' : 'Give Packs'}
+                        </button>
+                        <button type="button" disabled={loading} onClick={handleAddPacksAll}>
+                            {loading ? 'Adding...' : 'Give To All'}
                         </button>
                         <button type="button" className="aa-reset-button" disabled={loading} onClick={async () => {
                             const confirmed = window.confirm('Are you sure you want to reset ALL users\' packs to 6? This cannot be undone.');


### PR DESCRIPTION
## Summary
- allow admins to increment packs for every user
- support adding packs to all users from admin actions page

## Testing
- `npm test --silent`
- `cd backend && npm test --silent && cd ..`
- `cd frontend && npm test --silent -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3e077c688330b77156744afd48f2