### PR TITLE
Improve pending trade card scaling

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -33,6 +33,11 @@ const PendingTrades = () => {
   const [openTrade, setOpenTrade] = useState(null);
 const [panelOpen, setPanelOpen] = useState(false);
 const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const defaultCardScale = 1;
+  const [cardScale] = useState(() => {
+    const stored = localStorage.getItem('cardScale');
+    return stored !== null ? parseFloat(stored) : defaultCardScale;
+  });
 useEffect(() => {
   if (!panelOpen && openTrade) {
     const t = setTimeout(() => setOpenTrade(null), 300);
@@ -218,7 +223,7 @@ const navigate = useNavigate();
           {trade.offeredPacks > 0 && (
             <p className="pack-count">{trade.offeredPacks} packs</p>
           )}
-          <div className="card-grid">
+          <div className="card-grid" style={{ '--card-scale': cardScale }}>
             {trade.offeredItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard
@@ -237,7 +242,7 @@ const navigate = useNavigate();
           {trade.requestedPacks > 0 && (
             <p className="pack-count">{trade.requestedPacks} packs</p>
           )}
-          <div className="card-grid">
+          <div className="card-grid" style={{ '--card-scale': cardScale }}>
             {trade.requestedItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -243,31 +243,33 @@ body {
   overflow-y: auto;
 }
 .card-grid {
-  --card-scale: 0.7;
+  --card-scale: 1;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
   justify-items: center;
+  width: calc(100% / var(--card-scale));
+  transform: scale(var(--card-scale));
+  transform-origin: top left;
 }
 
 @media (max-width: 600px) {
   .card-grid {
-    --card-scale: 0.65;
-    grid-template-columns: repeat(2, 1fr);
+    --card-scale: 0.9;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
 @media (max-width: 400px) {
   .card-grid {
-    --card-scale: 0.55;
-    grid-template-columns: 1fr;
+    --card-scale: 0.8;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }
+
 .card-tile {
   width: 100%;
   max-width: 300px;
-  transform: scale(var(--card-scale));
-  transform-origin: top center;
 }
 .pack-count {
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- use persisted card scale from collection page on pending trades page
- make card grid responsive for 1-3 cards and various screen sizes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f4394af008330b12c9c2c81cc7afb