### PR TITLE
Add Negative card modifier

### DIFF
--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -2,6 +2,7 @@ const Pack = require('../models/packModel');
 const User = require('../models/userModel');
 const Modifier = require('../models/modifierModel');
 const { generateCardWithProbability, generatePack } = require('../helpers/cardHelpers');
+const MODIFIER_CHANCE = parseFloat(process.env.MODIFIER_CHANCE || '0.1');
 
 // Get all users with packs (Admin-only functionality)
 const getUsersWithPacks = async (req, res) => {
@@ -30,11 +31,11 @@ const openPack = async (req, res) => {
             return res.status(500).json({ message: 'Failed to generate a card' });
         }
 
-        // Add modifier logic here
-        const modifiers = await Modifier.find();
-        if (modifiers && modifiers.length > 0) {
-            const randomIndex = Math.floor(Math.random() * modifiers.length);
-            newCard.modifier = modifiers[randomIndex]._id;
+        const forceModifier = req.body?.forceModifier === true;
+        const negative = await Modifier.findOne({ name: 'Negative' });
+        if (negative && (forceModifier || Math.random() < MODIFIER_CHANCE)) {
+            newCard.modifier = negative._id;
+            newCard.name = `Negative ${newCard.name}`;
         }
 
         user.cards.push(newCard);
@@ -119,12 +120,12 @@ const openPacksForUser = async (req, res) => {
             return res.status(500).json({ message: 'Failed to generate cards for the pack' });
         }
 
-        // Add modifier logic here
-        const modifiers = await Modifier.find();
+        const forceModifier = req.body?.forceModifier === true;
+        const negative = await Modifier.findOne({ name: 'Negative' });
         for (const newCard of newCards) {
-            if (modifiers && modifiers.length > 0) {
-                const randomIndex = Math.floor(Math.random() * modifiers.length);
-                newCard.modifier = modifiers[randomIndex]._id;
+            if (negative && (forceModifier || Math.random() < MODIFIER_CHANCE)) {
+                newCard.modifier = negative._id;
+                newCard.name = `Negative ${newCard.name}`;
             }
         }
 

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -6,6 +6,7 @@ const cardSchema = new mongoose.Schema({
     mintNumber: Number,
     imageUrl: String,
     flavorText: String,
+    modifier: { type: mongoose.Schema.Types.ObjectId, ref: 'Modifier', default: null },
     acquiredAt: { type: Date, default: Date.now }, // Track when the card was acquired
 status: { type: String, enum: ['available', 'pending', 'escrow'], default: 'available' } // Card status
 });

--- a/backend/src/scripts/seedModifiers.js
+++ b/backend/src/scripts/seedModifiers.js
@@ -14,31 +14,25 @@ const seedModifiers = async () => {
     });
     console.log('MongoDB connected for seeding modifiers');
 
-    // Check if the Rainbow Holo modifier already exists
-    const existingModifier = await Modifier.findOne({ name: 'Rainbow Holo' });
+    // Check if the Negative modifier already exists
+    const existingModifier = await Modifier.findOne({ name: 'Negative' });
 
     if (!existingModifier) {
-      const rainbowHoloModifier = new Modifier({
-        name: 'Rainbow Holo',
-        description: 'Adds a rainbow holographic effect to the card name.',
-        css: JSON.stringify({
-          background: 'linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet)',
-          WebkitBackgroundClip: 'text',
-          backgroundClip: 'text',
-          color: 'transparent',
-          animation: 'rainbow 5s linear infinite',
-        }),
+      const negativeModifier = new Modifier({
+        name: 'Negative',
+        description: 'Inverts the card colours.',
+        css: JSON.stringify({}),
         blendMode: null,
-        filter: null,
-        animation: 'rainbow 5s linear infinite',
+        filter: 'invert(1)',
+        animation: null,
         overlayImage: null,
         overlayBlendMode: null,
       });
 
-      await rainbowHoloModifier.save();
-      console.log('Rainbow Holo modifier created');
+      await negativeModifier.save();
+      console.log('Negative modifier created');
     } else {
-      console.log('Rainbow Holo modifier already exists');
+      console.log('Negative modifier already exists');
     }
 
     mongoose.disconnect();

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -219,13 +219,7 @@ const BaseCard = ({
           </div>
         ) : (
           <>
-            <div
-              className={`card-name ${
-                modifierData?.name === 'Rainbow Holo' ? 'rainbow-holo' : ''
-              }`}
-            >
-              {name}
-            </div>
+            <div className="card-name">{name}</div>
 
             <div className="card-artwork">
               {rarity.toLowerCase()==='unique' ? (
@@ -250,14 +244,8 @@ const BaseCard = ({
                 <img src={image} alt={name} draggable={false} loading="lazy" />
               )}
 
-              {modifierData?.name === 'Rainbow Holo' && (
-                <div
-                  className="rainbow-holo-image"
-                  style={{
-                    '--cursor-x': `${cursorPosition.x}px`,
-                    '--cursor-y': `${cursorPosition.y}px`,
-                  }}
-                />
+              {modifierData?.name === 'Negative' && (
+                <div className="negative-overlay" />
               )}
             </div>
 

--- a/frontend/src/pages/AdminDashboardPage.js
+++ b/frontend/src/pages/AdminDashboardPage.js
@@ -36,6 +36,7 @@ const AdminDashboardPage = ({ user }) => {
     // Pack types
     const [packTypes, setPackTypes] = useState([]);
     const [selectedPackTypeId, setSelectedPackTypeId] = useState('');
+    const [forceModifier, setForceModifier] = useState(false);
 
     // Rarity color mapping
     const cardRarities = {
@@ -152,7 +153,7 @@ const AdminDashboardPage = ({ user }) => {
                 `/api/packs/admin/openPacksForUser/${selectedUser._id}`,
                 {
                     method: 'POST',
-                    body: JSON.stringify({ templateId: selectedPackTypeId })
+                    body: JSON.stringify({ templateId: selectedPackTypeId, forceModifier })
                 }
             );
             const { newCards } = res;
@@ -324,6 +325,14 @@ const AdminDashboardPage = ({ user }) => {
                                     </option>
                                 ))}
                             </select>
+                            <label style={{ marginLeft: '1rem' }}>
+                                <input
+                                    type="checkbox"
+                                    checked={forceModifier}
+                                    onChange={(e) => setForceModifier(e.target.checked)}
+                                />
+                                Force Modifier
+                            </label>
                             <button
                                 onClick={openPackForUser}
                                 disabled={loading || isOpeningAnimation || selectedUser.packs <= 0}

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -660,7 +660,7 @@
         -webkit-text-stroke: 1px white;
     }
 
-    .card-container.divine:hover .card-mint {
+.card-container.divine:hover .card-mint {
         font-size: 1.2rem;
         margin-bottom: 10px;
         color: white;
@@ -674,7 +674,17 @@
         transition: text-shadow 0.3s ease;
         -webkit-text-stroke: 1px white;
         text-shadow: 1px 1px 5px black;
-    }
+}
+
+.negative-overlay {
+    position: absolute;
+    inset: 8px;
+    border-radius: calc(15px - 8px);
+    background: white;
+    mix-blend-mode: difference;
+    pointer-events: none;
+    z-index: 5;
+}
 
 
 /**************************************


### PR DESCRIPTION
## Summary
- seed only a new "Negative" modifier
- store modifier reference on user cards
- apply Negative modifier when packs are opened
- support forcing modifiers from the admin dashboard
- display Negative overlay and remove Rainbow code

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850580d053483308eb1c6a57ae24b1b