### PR TITLE
Add random modifier option for admin pack opens

### DIFF
--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -32,10 +32,24 @@ const openPack = async (req, res) => {
         }
 
         const forceModifier = req.body?.forceModifier === true;
-        const negative = await Modifier.findOne({ name: 'Negative' });
-        if (negative && (forceModifier || Math.random() < MODIFIER_CHANCE)) {
-            newCard.modifier = negative._id;
-            newCard.name = `Negative ${newCard.name}`;
+        let modifierDoc = null;
+
+        if (forceModifier) {
+            const mods = await Modifier.find();
+            if (mods && mods.length > 0) {
+                const idx = Math.floor(Math.random() * mods.length);
+                modifierDoc = mods[idx];
+            }
+        } else {
+            const negative = await Modifier.findOne({ name: 'Negative' });
+            if (negative && Math.random() < MODIFIER_CHANCE) {
+                modifierDoc = negative;
+            }
+        }
+
+        if (modifierDoc) {
+            newCard.modifier = modifierDoc._id;
+            newCard.name = `${modifierDoc.name} ${newCard.name}`;
         }
 
         user.cards.push(newCard);
@@ -121,11 +135,20 @@ const openPacksForUser = async (req, res) => {
         }
 
         const forceModifier = req.body?.forceModifier === true;
-        const negative = await Modifier.findOne({ name: 'Negative' });
+        let mods = null;
+        if (forceModifier) {
+            mods = await Modifier.find();
+        } else {
+            const negative = await Modifier.findOne({ name: 'Negative' });
+            mods = negative ? [negative] : [];
+        }
+
         for (const newCard of newCards) {
-            if (negative && (forceModifier || Math.random() < MODIFIER_CHANCE)) {
-                newCard.modifier = negative._id;
-                newCard.name = `Negative ${newCard.name}`;
+            if (mods && mods.length > 0 && (forceModifier || Math.random() < MODIFIER_CHANCE)) {
+                const idx = forceModifier ? Math.floor(Math.random() * mods.length) : 0;
+                const mod = mods[idx];
+                newCard.modifier = mod._id;
+                newCard.name = `${mod.name} ${newCard.name}`;
             }
         }
 

--- a/backend/src/scripts/seedModifiers.js
+++ b/backend/src/scripts/seedModifiers.js
@@ -35,6 +35,46 @@ const seedModifiers = async () => {
       console.log('Negative modifier already exists');
     }
 
+    const glitchExisting = await Modifier.findOne({ name: 'Glitch' });
+
+    if (!glitchExisting) {
+      const glitchModifier = new Modifier({
+        name: 'Glitch',
+        description: 'Static glitch overlay.',
+        css: JSON.stringify({}),
+        blendMode: null,
+        filter: null,
+        animation: null,
+        overlayImage: null,
+        overlayBlendMode: null,
+      });
+
+      await glitchModifier.save();
+      console.log('Glitch modifier created');
+    } else {
+      console.log('Glitch modifier already exists');
+    }
+
+    const prismExisting = await Modifier.findOne({ name: 'Prismatic Hologram' });
+
+    if (!prismExisting) {
+      const prismModifier = new Modifier({
+        name: 'Prismatic Hologram',
+        description: 'Rainbow holographic shimmer.',
+        css: JSON.stringify({}),
+        blendMode: null,
+        filter: null,
+        animation: null,
+        overlayImage: null,
+        overlayBlendMode: null,
+      });
+
+      await prismModifier.save();
+      console.log('Prismatic Hologram modifier created');
+    } else {
+      console.log('Prismatic Hologram modifier already exists');
+    }
+
     mongoose.disconnect();
     console.log('MongoDB disconnected');
   } catch (error) {

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -266,6 +266,12 @@ const BaseCard = ({
       {modifierData?.name === 'Negative' && (
         <div className="negative-overlay" />
       )}
+      {modifierData?.name === 'Glitch' && (
+        <div className="glitch-overlay" />
+      )}
+      {modifierData?.name === 'Prismatic Hologram' && (
+        <div className="prismatic-hologram-overlay" />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/AdminDashboardPage.js
+++ b/frontend/src/pages/AdminDashboardPage.js
@@ -331,7 +331,7 @@ const AdminDashboardPage = ({ user }) => {
                                     checked={forceModifier}
                                     onChange={(e) => setForceModifier(e.target.checked)}
                                 />
-                                Force Modifier
+                                Force Random Modifier
                             </label>
                             <button
                                 onClick={openPackForUser}

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -676,6 +676,45 @@
         text-shadow: 1px 1px 5px black;
 }
 
+.glitch-overlay,
+.prismatic-hologram-overlay {
+    position: absolute;
+    inset: 8px;
+    border-radius: calc(15px - 8px);
+    pointer-events: none;
+    z-index: 5;
+}
+
+.glitch-overlay {
+    background: url('../assets/textures/static.gif') center/cover;
+    mix-blend-mode: screen;
+    opacity: 0.6;
+    animation: glitchShift 1s steps(2, end) infinite;
+}
+
+@keyframes glitchShift {
+    0% { transform: translate(0,0); }
+    20% { transform: translate(-2px, 2px); }
+    40% { transform: translate(2px, -2px); }
+    60% { transform: translate(-1px, 1px); }
+    80% { transform: translate(1px, -1px); }
+    100% { transform: translate(0,0); }
+}
+
+.prismatic-hologram-overlay {
+    background: url('../assets/textures/rainbowpop.gif') center/cover;
+    mix-blend-mode: overlay;
+    opacity: 0.7;
+    background-size: 150% 150%;
+    animation: prismMove 4s linear infinite;
+}
+
+@keyframes prismMove {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}
+
 .negative-overlay {
     position: absolute;
     inset: 8px;


### PR DESCRIPTION
## Summary
- adjust pack opening logic to select a random modifier when the admin checkbox is used
- update checkbox label in the dashboard to **Force Random Modifier**

## Testing
- `npm test` within `frontend` *(fails: react-scripts not found)*
- `npm test` within `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68509291c43083309da42d074bf919e0