### PR TITLE
Add modifier toggles to catalogue

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -29,15 +29,23 @@ const BaseCard = ({
 
   useEffect(() => {
     const fetchModifier = async () => {
-      if (modifier) {
-        try {
-          const data = await fetchWithAuth(`/api/modifiers/${modifier}`, { method: 'GET' });
-          setModifierData(data);
-        } catch (error) {
-          console.error('Error fetching modifier:', error.message);
-        }
-      } else {
+      if (!modifier) {
         setModifierData(null);
+        return;
+      }
+
+      // Treat plain names as local modifiers and skip API fetch
+      const isObjectId = /^[0-9a-fA-F]{24}$/.test(modifier);
+      if (!isObjectId) {
+        setModifierData({ name: modifier });
+        return;
+      }
+
+      try {
+        const data = await fetchWithAuth(`/api/modifiers/${modifier}`, { method: 'GET' });
+        setModifierData(data);
+      } catch (error) {
+        console.error('Error fetching modifier:', error.message);
       }
     };
     fetchModifier();

--- a/frontend/src/constants/modifiers.js
+++ b/frontend/src/constants/modifiers.js
@@ -1,0 +1,6 @@
+export const modifiers = [
+  { name: 'None', color: '#555' },
+  { name: 'Negative', color: '#26a69a' },
+  { name: 'Glitch', color: '#ec407a' },
+  { name: 'Prismatic', color: '#ffee58', text: '#000' },
+];

--- a/frontend/src/pages/CataloguePage.js
+++ b/frontend/src/pages/CataloguePage.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { fetchCards } from '../utils/api';
 import BaseCard from '../components/BaseCard';
 import LoadingSpinner from '../components/LoadingSpinner';
+import { modifiers } from '../constants/modifiers';
 import '../styles/CataloguePage.css';
 
 const rarityData = [
@@ -31,6 +32,7 @@ const CataloguePage = () => {
 
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedRarity, setSelectedRarity] = useState('Basic');
+    const [selectedModifier, setSelectedModifier] = useState('None');
     const [sortOption, setSortOption] = useState('name');
     const [sortOrder, setSortOrder] = useState('asc');
     const [now, setNow] = useState(new Date());
@@ -71,6 +73,7 @@ const CataloguePage = () => {
 
     const handleSearchChange = (e) => setSearchQuery(e.target.value);
     const handleRarityChange = (rarityName) => setSelectedRarity(rarityName);
+    const handleModifierChange = (name) => setSelectedModifier(name);
     const handleSortChange = (e) => setSortOption(e.target.value);
     const handleSortOrderChange = (e) => setSortOrder(e.target.value);
 
@@ -123,6 +126,48 @@ const CataloguePage = () => {
                 card in a different style.
             </p>
 
+            <div className="cata-rarity-selector">
+                {rarityData.map((r) => {
+                    const textColor = r.name === 'Divine' ? '#000' : '#fff';
+                    return (
+                        <button
+                            key={r.name}
+                            onClick={() => handleRarityChange(r.name)}
+                            className={`cata-rarity-button ${selectedRarity === r.name ? 'active' : ''}`}
+                            style={{
+                                backgroundColor: r.color,
+                                color: textColor,
+                                padding: '8px 12px',
+                                border: '2px solid #888',
+                            }}
+                        >
+                            {r.name}
+                        </button>
+                    );
+                })}
+            </div>
+
+            <div className="cata-modifier-selector">
+                {modifiers.map((m) => {
+                    const textColor = m.text || '#fff';
+                    return (
+                        <button
+                            key={m.name}
+                            onClick={() => handleModifierChange(m.name)}
+                            className={`cata-modifier-button ${selectedModifier === m.name ? 'active' : ''}`}
+                            style={{
+                                backgroundColor: m.color,
+                                color: textColor,
+                                padding: '8px 12px',
+                                border: '2px solid #888',
+                            }}
+                        >
+                            {m.name}
+                        </button>
+                    );
+                })}
+            </div>
+
             <div className="cata-filters-container">
                 <div className="cata-search-box">
                     <input
@@ -131,26 +176,6 @@ const CataloguePage = () => {
                         onChange={handleSearchChange}
                         placeholder="Search cards..."
                     />
-                </div>
-                <div className="cata-rarity-selector">
-                    {rarityData.map((r) => {
-                        const textColor = r.name === 'Divine' ? '#000' : '#fff';
-                        return (
-                            <button
-                                key={r.name}
-                                onClick={() => handleRarityChange(r.name)}
-                                className={`cata-rarity-button ${selectedRarity === r.name ? 'active' : ''}`}
-                                style={{
-                                    backgroundColor: r.color,
-                                    color: textColor,
-                                    padding: '8px 12px',
-                                    border: '2px solid #888',
-                                }}
-                            >
-                                {r.name}
-                            </button>
-                        );
-                    })}
                 </div>
                 <div className="cata-sort-box">
                     <label htmlFor="sortField">Sort by:</label>
@@ -186,7 +211,7 @@ const CataloguePage = () => {
                                         description={card.flavorText}
                                         rarity={selectedRarity}
                                         mintNumber={card.mintNumber}
-                                        modifier={card.modifier}
+                                        modifier={selectedModifier === 'None' ? null : selectedModifier}
                                     />
                                     <RemainingBadge remaining={remaining} />
                                     {to && timeLeft > 0 && (
@@ -226,7 +251,7 @@ const CataloguePage = () => {
                                         description={card.flavorText}
                                         rarity={selectedRarity}
                                         mintNumber={card.mintNumber}
-                                        modifier={card.modifier}
+                                        modifier={selectedModifier === 'None' ? null : selectedModifier}
                                     />
                                     <RemainingBadge remaining={remaining} />
                                     <div className="cata-overlay-badge cata-timeleft-badge">
@@ -257,7 +282,7 @@ const CataloguePage = () => {
                                         description={card.flavorText}
                                         rarity={selectedRarity}
                                         mintNumber={card.mintNumber}
-                                        modifier={card.modifier}
+                                        modifier={selectedModifier === 'None' ? null : selectedModifier}
                                     />
                                     <RemainingBadge remaining={remaining} />
                                 </div>

--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -84,6 +84,32 @@
     box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
 }
 
+/* Modifier selector buttons */
+.cata-modifier-selector {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.cata-modifier-button {
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    font-size: 1rem;
+}
+
+.cata-modifier-button:hover {
+    transform: scale(1.05);
+    opacity: 0.9;
+}
+
+.cata-modifier-button.active {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
+}
+
 /* Sort box styling */
 .cata-sort-box {
     display: flex;


### PR DESCRIPTION
## Summary
- list modifier names and colors
- allow BaseCard modifier prop to accept plain names
- add modifier selector to the catalogue page
- style modifier buttons like rarity buttons

## Testing
- `npm test` (frontend) *(fails: react-scripts not found)*
- `npm test` (backend) *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685183b526c48330975f09a83c8bec55