### PR TITLE
Enable 5% modifier chance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MONGO_URI=
 CLIENT_URL=
 FRONTEND_URL=
 CHANNEL_POINTS_COST=5000
-MODIFIER_CHANCE=0.1
+MODIFIER_CHANCE=0.05
 ```
 
 After configuring the backend environment, seed the default card modifiers:


### PR DESCRIPTION
## Summary
- set default `MODIFIER_CHANCE` to 0.05 in README and controller
- apply random modifiers without needing the `forceModifier` checkbox

## Testing
- `npm test` within `backend` *(fails: Error: no test specified)*
- `npm install` and `npm test --silent` within `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6851841518ac833082817641615ca9b7