### PR TITLE
Fix offer acceptance and card scaling

### DIFF
--- a/backend/src/services/marketService.js
+++ b/backend/src/services/marketService.js
@@ -95,9 +95,11 @@ async function acceptOffer(listingId, offerId, userId, session) {
   // Check if buyer has all offered cards specified in the offer
   if (offeredCardDetails.length !== offer.offeredCards.length) {
       console.log('[Accept Offer Service] Error: Buyer does not possess all offered cards.');
-      // IMPORTANT: Abort transaction here as state is inconsistent
-      throw new Error('Buyer does not possess all offered cards.'); // Throw error to trigger catch block and abort transaction
-      // return { success: false, status: 400, message: 'Buyer does not possess all offered cards.' }; // Don't just return, abort transaction
+      return {
+        success: false,
+        status: 400,
+        message: 'Buyer does not possess all offered cards.'
+      };
   }
   console.log('[Accept Offer Service] Buyer possesses all offered cards.');
 

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -239,10 +239,34 @@
     opacity: 1 !important;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 1200px) {
     .market-user-collection-grid,
     .market-selected-cards-grid,
     .offered-cards-grid {
-        --card-scale: 0.8;
+        --card-scale: 0.85;
+    }
+}
+
+@media (max-width: 992px) {
+    .market-user-collection-grid,
+    .market-selected-cards-grid,
+    .offered-cards-grid {
+        --card-scale: 0.75;
+    }
+}
+
+@media (max-width: 768px) {
+    .market-user-collection-grid,
+    .market-selected-cards-grid,
+    .offered-cards-grid {
+        --card-scale: 0.65;
+    }
+}
+
+@media (max-width: 480px) {
+    .market-user-collection-grid,
+    .market-selected-cards-grid,
+    .offered-cards-grid {
+        --card-scale: 0.55;
     }
 }


### PR DESCRIPTION
## Summary
- fix accept offer logic to return a helpful message instead of throwing
- improve responsive scaling for cards shown when making/offering offers

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3fa425c83308650ed14b322a09c