### PR TITLE
Add favorite card selection on profile

### DIFF
--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -39,6 +39,10 @@ const userSchema = new mongoose.Schema({
             flavorText: { type: String }
         },
     ],
+    favoriteCard: {
+        name: String,
+        rarity: String,
+    },
     notifications: [notificationSchema], // NEW: Notifications for the user
     firstLogin: { type: Boolean, default: false },
     isAdmin: { type: Boolean, default: false },

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -5,6 +5,8 @@ const {
     getProfileByUsername,
     getFeaturedCards,
     updateFeaturedCards,
+    getFavoriteCard,
+    updateFavoriteCard,
     searchUsers,
 } = require('../controllers/userController');
 const { protect } = require('../middleware/authMiddleware');
@@ -41,6 +43,10 @@ router.get('/featured-cards', protect, getFeaturedCards);
 
 // Route to update user's featured cards
 router.put('/featured-cards', protect, updateFeaturedCards);
+
+// Favorite card routes
+router.get('/favorite-card', protect, getFavoriteCard);
+router.put('/favorite-card', protect, updateFavoriteCard);
 
 // Route to fetch all cards in the user's collection
 router.get('/:userId/collection', protect, async (req, res) => {

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -6,13 +6,21 @@ import {
     fetchUserProfile,
     fetchUserProfileByUsername,
     fetchUserCollection,
+    fetchFavoriteCard,
+    updateFavoriteCard,
+    searchCardsByName,
 } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner';
 import '../styles/App.css';
 import '../styles/ProfilePage.css';
+import { rarities } from '../constants/rarities';
 
 const ProfilePage = () => {
     const [featuredCards, setFeaturedCards] = useState([]);
+    const [favoriteCard, setFavoriteCard] = useState(null);
+    const [cardQuery, setCardQuery] = useState('');
+    const [cardResults, setCardResults] = useState([]);
+    const [selectedRarity, setSelectedRarity] = useState('');
     const [collectionCount, setCollectionCount] = useState(0);
     const [currentPacks, setCurrentPacks] = useState(0);
     const [openedPacks, setOpenedPacks] = useState(0);
@@ -41,6 +49,18 @@ const ProfilePage = () => {
                 setAchievements(profile.achievements || []);
 
                 let tempFeatured = profile.featuredCards || [];
+                if (!routeUsername) {
+                    try {
+                        const fav = await fetchFavoriteCard();
+                        setFavoriteCard(fav);
+                        if (fav && fav.rarity) setSelectedRarity(fav.rarity);
+                        if (fav && fav.name) setCardQuery(fav.name);
+                    } catch (e) {
+                        console.error('Error fetching favorite card:', e);
+                    }
+                } else {
+                    setFavoriteCard(profile.favoriteCard || null);
+                }
                 if (profile._id) {
                     const collectionData = await fetchUserCollection(profile._id);
                     setCollectionCount(collectionData.cards ? collectionData.cards.length : 0);
@@ -62,8 +82,38 @@ const ProfilePage = () => {
         fetchProfileData();
     }, [routeUsername]);
 
+    // Debounced search for card names when editing favorite card
+    useEffect(() => {
+        const fetchResults = async () => {
+            if (cardQuery && !routeUsername) {
+                const results = await searchCardsByName(cardQuery);
+                setCardResults(results);
+            } else {
+                setCardResults([]);
+            }
+        };
+        const t = setTimeout(fetchResults, 300);
+        return () => clearTimeout(t);
+    }, [cardQuery, routeUsername]);
+
     const handleViewCollection = () => {
         navigate(`/collection/${username}`);
+    };
+
+    const handleSelectCard = (card) => {
+        setCardQuery(card.name);
+        setCardResults([]);
+        setFavoriteCard({ ...favoriteCard, name: card.name, imageUrl: card.imageUrl, flavorText: card.flavorText });
+    };
+
+    const saveFavorite = async () => {
+        try {
+            await updateFavoriteCard(cardQuery, selectedRarity);
+            const fav = await fetchFavoriteCard();
+            setFavoriteCard(fav);
+        } catch (err) {
+            console.error('Error saving favorite card:', err);
+        }
     };
 
     if (loading) {
@@ -134,6 +184,57 @@ const ProfilePage = () => {
                         );
                     })}
                 </div>
+            </div>
+
+            <div className="favorite-card-container">
+                <h2>Favorite Card Wanted</h2>
+                {favoriteCard && favoriteCard.name ? (
+                    <div className="favorite-card-display">
+                        <BaseCard
+                            name={favoriteCard.name}
+                            image={favoriteCard.imageUrl}
+                            rarity={favoriteCard.rarity}
+                            description={favoriteCard.flavorText}
+                        />
+                    </div>
+                ) : (
+                    <p>No favorite card selected.</p>
+                )}
+                {!routeUsername && (
+                    <div className="favorite-card-form">
+                        <div className="favorite-input">
+                            <input
+                                type="text"
+                                className="search-bar"
+                                placeholder="Search card..."
+                                value={cardQuery}
+                                onChange={(e) => setCardQuery(e.target.value)}
+                            />
+                            {cardResults.length > 0 && (
+                                <ul className="search-dropdown">
+                                    {cardResults.map((c) => (
+                                        <li
+                                            key={c._id}
+                                            className="search-result-item"
+                                            onMouseDown={() => handleSelectCard(c)}
+                                        >
+                                            {c.name}
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                        <select value={selectedRarity} onChange={(e) => setSelectedRarity(e.target.value)}>
+                            <option value="">Select rarity</option>
+                            {rarities.map((r) => (
+                                <option key={r.name} value={r.name}>
+                                    {r.name}
+                                </option>
+                            ))}
+                        </select>
+                        <button onClick={saveFavorite}>Save</button>
+                    </div>
+                )}
             </div>
 
             <div className="featured-cards-container">

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -261,6 +261,48 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 
+/* Favorite Card Panel */
+.favorite-card-container {
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    padding: 2rem;
+    border-radius: var(--border-radius);
+    text-align: center;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.favorite-card-form {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.favorite-card-form select,
+.favorite-card-form button {
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-dark);
+    background: var(--surface-darker);
+    color: var(--text-primary);
+}
+
+.favorite-card-form button {
+    background-color: var(--brand-primary);
+    border: none;
+    cursor: pointer;
+}
+
+.favorite-input {
+    position: relative;
+    width: 100%;
+    max-width: 300px;
+}
+
     .view-collection-button:hover {
         background-color: #722ebf;
         transform: scale(1.05);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -159,6 +159,31 @@ export const updateFeaturedCards = async (featuredCards) => {
     }
 };
 
+// Fetch favorite card for the logged-in user
+export const fetchFavoriteCard = async () => {
+    try {
+        const response = await fetchWithAuth("/api/users/favorite-card", { method: "GET" });
+        return response.favoriteCard;
+    } catch (error) {
+        console.error("[API] Error fetching favorite card:", error.message);
+        throw error;
+    }
+};
+
+// Update favorite card for the logged-in user
+export const updateFavoriteCard = async (name, rarity) => {
+    try {
+        const response = await fetchWithAuth("/api/users/favorite-card", {
+            method: "PUT",
+            body: JSON.stringify({ name, rarity }),
+        });
+        return response.favoriteCard;
+    } catch (error) {
+        console.error("[API] Error updating favorite card:", error.message);
+        throw error;
+    }
+};
+
 // Create a new trade
 export const createTrade = async (tradeData) => {
     try {


### PR DESCRIPTION
## Summary
- extend `User` model with `favoriteCard` field
- expose REST routes and controllers for getting/updating a favorite card
- add API helpers for favorite card functions
- implement a favorite card panel on the profile page
- include minimal styling for the new panel

## Testing
- `npm test` *(backend)*
- `npm test` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6851e44b1be883309e2169bf8f131ba4