### PR TITLE
Add trade and market tiles on profile

### DIFF
--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -119,6 +119,22 @@ router.get('/listings', protect, async (req, res) => {
     }
 });
 
+// GET /api/market/user/:userId/listings - Get active listings for a specific user
+router.get('/user/:userId/listings', protect, async (req, res) => {
+    try {
+        const limit = parseInt(req.query.limit) || 3;
+        const listings = await MarketListing.find({ owner: req.params.userId, status: 'active' })
+            .populate('owner', 'username')
+            .populate('offers.offerer', 'username')
+            .sort({ createdAt: -1 })
+            .limit(limit);
+        res.status(200).json({ listings });
+    } catch (error) {
+        console.error('Error fetching user market listings:', error);
+        res.status(500).json({ message: 'Server error fetching user listings' });
+    }
+});
+
 // GET /api/market/listings/:id - Get a single market listing.
 router.get('/listings/:id', protect, async (req, res) => {
     try {

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -392,3 +392,54 @@ body {
 .profile-overview * {
     cursor: default !important;
 }
+
+/* Trade & Collection Actions */
+.trade-actions-container {
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    padding: 1.5rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+    max-width: 600px;
+    width: 100%;
+    margin: 0 auto;
+    grid-column: span 2;
+}
+
+.initiate-trade-button,
+.trade-actions-container .view-collection-button {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.initiate-trade-button {
+    background-color: var(--brand-secondary);
+    color: var(--background-dark);
+}
+
+.user-listings-container {
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    padding: 2rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+    grid-column: 1 / -1;
+    text-align: center;
+}
+
+.user-listings {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -332,3 +332,14 @@ export const deleteNotification = async (notificationId) => {
 export const clearNotifications = async () => {
     return fetchWithAuth('/api/notifications/clear', { method: 'DELETE' });
 };
+
+// Fetch active market listings for a specific user
+export const fetchUserMarketListings = async (userId, limit = 3) => {
+    try {
+        const response = await fetchWithAuth(`/api/market/user/${userId}/listings?limit=${limit}`);
+        return response.listings || [];
+    } catch (error) {
+        console.error('[API] Error fetching user market listings:', error.message);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- show user market listing endpoint
- fetch user market listings in frontend
- add trade initiation and listing display to profile page
- style new profile tiles

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd0493e88330add87772fa75bc05