### PR TITLE
Fix profile listings layout

### DIFF
--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -123,12 +123,18 @@ router.get('/listings', protect, async (req, res) => {
 router.get('/user/:userId/listings', protect, async (req, res) => {
     try {
         const limit = parseInt(req.query.limit) || 3;
-        const listings = await MarketListing.find({ owner: req.params.userId, status: 'active' })
-            .populate('owner', 'username')
-            .populate('offers.offerer', 'username')
-            .sort({ createdAt: -1 })
-            .limit(limit);
-        res.status(200).json({ listings });
+        const query = { owner: req.params.userId, status: 'active' };
+
+        const [listings, total] = await Promise.all([
+            MarketListing.find(query)
+                .populate('owner', 'username')
+                .populate('offers.offerer', 'username')
+                .sort({ createdAt: -1 })
+                .limit(limit),
+            MarketListing.countDocuments(query),
+        ]);
+
+        res.status(200).json({ listings, total });
     } catch (error) {
         console.error('Error fetching user market listings:', error);
         res.status(500).json({ message: 'Server error fetching user listings' });

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -32,6 +32,7 @@ const ProfilePage = () => {
     const [username, setUsername] = useState('');
     const [profileId, setProfileId] = useState(null);
     const [userListings, setUserListings] = useState([]);
+    const [moreListings, setMoreListings] = useState(0);
     const navigate = useNavigate();
     const { username: routeUsername } = useParams();
 
@@ -104,8 +105,9 @@ const ProfilePage = () => {
         const fetchListings = async () => {
             if (!profileId) return;
             try {
-                const listings = await fetchUserMarketListings(profileId, 3);
+                const { listings, total } = await fetchUserMarketListings(profileId, 3);
                 setUserListings(listings);
+                setMoreListings(Math.max(total - listings.length, 0));
             } catch (e) {
                 console.error('Error fetching user listings:', e);
             }
@@ -341,7 +343,7 @@ const ProfilePage = () => {
                                     />
                                 </div>
                                 <p className="offers-count">Offers: {listing.offers ? listing.offers.length : 0}</p>
-                                <Link to={`/market/listing/${listing._id}`}> 
+                                <Link to={`/market/listing/${listing._id}`}>
                                     <button className="view-listing-button">View Listing</button>
                                 </Link>
                             </div>
@@ -350,33 +352,8 @@ const ProfilePage = () => {
                 ) : (
                     <p>No active listings.</p>
                 )}
-            </div>
-
-            <div className="user-listings-container">
-                <h2>{username}'s Market Listings</h2>
-                {userListings.length > 0 ? (
-                    <div className="user-listings">
-                        {userListings.map((listing) => (
-                            <div key={listing._id} className="listing-card">
-                                <div className="listing-card-content">
-                                    <BaseCard
-                                        name={listing.card.name}
-                                        image={listing.card.imageUrl}
-                                        rarity={listing.card.rarity}
-                                        description={listing.card.flavorText}
-                                        mintNumber={listing.card.mintNumber}
-                                        modifier={listing.card.modifier}
-                                    />
-                                </div>
-                                <p className="offers-count">Offers: {listing.offers ? listing.offers.length : 0}</p>
-                                <Link to={`/market/listing/${listing._id}`}> 
-                                    <button className="view-listing-button">View Listing</button>
-                                </Link>
-                            </div>
-                        ))}
-                    </div>
-                ) : (
-                    <p>No active listings.</p>
+                {moreListings > 0 && (
+                    <p className="more-listings">{moreListings} more on the market</p>
                 )}
             </div>
         </div>

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -396,15 +396,20 @@ body {
     grid-column: span 1;
 }
 
-.initiate-trade-button,
-.trade-actions-container .view-collection-button {
+.trade-actions-container button {
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 1.25rem;
     font-size: 1rem;
-    border-radius: 8px;
+    border-radius: var(--border-radius);
     border: none;
     cursor: pointer;
-    font-weight: bold;
+    font-weight: 600;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.trade-actions-container button:hover {
+    transform: scale(1.05);
 }
 
 .initiate-trade-button {
@@ -428,4 +433,10 @@ body {
     justify-content: center;
     gap: 1rem;
     margin-top: 1rem;
+}
+
+.more-listings {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--brand-secondary);
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -337,7 +337,10 @@ export const clearNotifications = async () => {
 export const fetchUserMarketListings = async (userId, limit = 3) => {
     try {
         const response = await fetchWithAuth(`/api/market/user/${userId}/listings?limit=${limit}`);
-        return response.listings || [];
+        return {
+            listings: response.listings || [],
+            total: response.total || 0,
+        };
     } catch (error) {
         console.error('[API] Error fetching user market listings:', error.message);
         throw error;


### PR DESCRIPTION
## Summary
- remove duplicate listing section on profile page
- return total listing count from backend
- show count of additional listings
- tweak trade action buttons for consistent styling

## Testing
- `npm test --silent` in `frontend` *(fails: No tests found)*
- `npm test --silent` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4631b88833097885754041adf91