### PR TITLE
Fix self-trading loophole

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -196,6 +196,7 @@ const searchUsers = async (req, res) => {
         }
         const users = await User.find({
             username: { $regex: query, $options: 'i' },
+            _id: { $ne: req.userId }
         }).select('username').lean();
         res.status(200).json(users);
     } catch (error) {

--- a/backend/src/services/tradeService.js
+++ b/backend/src/services/tradeService.js
@@ -26,6 +26,11 @@ async function createTrade(senderId, { recipient, offeredItems, requestedItems, 
     }
     if (!recipientUser) return { success: false, status: 404, message: 'Recipient not found' };
 
+    // Re-check after lookup to prevent trading with self when username is provided
+    if (recipientUser._id.toString() === senderId) {
+      return { success: false, status: 400, message: 'You cannot create a trade with yourself.' };
+    }
+
     if (offeredPacks > sender.packs) {
       return { success: false, status: 400, message: `You only have ${sender.packs} pack(s), but tried to offer ${offeredPacks}.` };
     }

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -59,7 +59,10 @@ const TradingPage = ({ userId }) => {
     useEffect(() => {
         if (searchQuery.length > 1) {
             searchUsers(searchQuery)
-                .then(setUserSuggestions)
+                .then((results) => {
+                    const filtered = loggedInUser ? results.filter(u => u.username !== loggedInUser.username) : results;
+                    setUserSuggestions(filtered);
+                })
                 .catch(console.error);
         } else {
             setUserSuggestions([]);
@@ -80,6 +83,10 @@ const TradingPage = ({ userId }) => {
     }, [selectedUser, loggedInUser]);
 
     const handleUserSelect = (username) => {
+        if (loggedInUser && username === loggedInUser.username) {
+            window.showToast("You cannot trade with yourself!", "warning");
+            return;
+        }
         setSelectedUser(username);
         setSearchQuery("");
         setUserSuggestions([]);
@@ -133,6 +140,10 @@ const TradingPage = ({ userId }) => {
     const handleSubmit = async () => {
         if (!selectedUser) {
             window.showToast("Select a user first!", "warning");
+            return;
+        }
+        if (loggedInUser && selectedUser === loggedInUser.username) {
+            window.showToast("You cannot trade with yourself!", "warning");
             return;
         }
         if (!tradeOffer.length && !offeredPacks) {


### PR DESCRIPTION
## Summary
- prevent users from trading with themselves in `tradeService`
- exclude the logged in user from search results
- guard against self-trades in the frontend trading page

## Testing
- `npm test` (fails: Missing script)
- `cd backend && npm test` (fails: no test specified)
- `cd frontend && npm test` (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_68532766d5f083309a53a5962ab04b4c