### PR TITLE
Optimize modifier loading

### DIFF
--- a/backend/src/controllers/collectionController.js
+++ b/backend/src/controllers/collectionController.js
@@ -6,8 +6,8 @@ const getLoggedInUserCollection = async (req, res) => {
     try {
         const { search = '', rarity = '', sort = '', page = 1, limit = 30 } = req.query;
 
-        // Retrieve the logged-in user's collection
-        const user = await User.findById(req.user._id).populate('cards');
+        // Retrieve the logged-in user's collection and populate modifier data
+        const user = await User.findById(req.user._id).populate('cards.modifier');
         if (!user) {
             console.error('[ERROR] Logged-in user not found:', req.user._id);
             return res.status(404).json({ message: 'User not found' });
@@ -60,10 +60,10 @@ const getCollectionByIdentifier = async (req, res) => {
         // Explicit ObjectId check
         if (mongoose.Types.ObjectId.isValid(identifier)) {
             console.log(`[DEBUG] Querying by ObjectId: ${identifier}`);
-            user = await User.findOne({ _id: identifier }).populate('cards');
+            user = await User.findOne({ _id: identifier }).populate('cards.modifier');
         } else {
             console.log(`[DEBUG] Querying by username: ${identifier}`);
-            user = await User.findOne({ username: identifier }).populate('cards');
+            user = await User.findOne({ username: identifier }).populate('cards.modifier');
         }
 
         if (!user) {

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -34,8 +34,14 @@ const BaseCard = ({
         return;
       }
 
+      // If modifier comes as a populated object, use it directly
+      if (typeof modifier === 'object' && modifier.name) {
+        setModifierData(modifier);
+        return;
+      }
+
       // Treat plain names as local modifiers and skip API fetch
-      const isObjectId = /^[0-9a-fA-F]{24}$/.test(modifier);
+      const isObjectId = typeof modifier === 'string' && /^[0-9a-fA-F]{24}$/.test(modifier);
       if (!isObjectId) {
         setModifierData({ name: modifier });
         return;


### PR DESCRIPTION
## Summary
- populate modifier details when fetching collections
- skip extra API calls if modifier data already present in the card component

## Testing
- `npm test --silent --yes` in `frontend` (no tests)
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853e6b5a41883308d4950d075868099