### PR TITLE
Update API env variable usage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,7 +22,7 @@ import Toast from './components/Toast';
 
 import 'normalize.css';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
 
 const App = () => {
     const [user, setUser] = useState(null);

--- a/frontend/src/pages/MarketPage.js
+++ b/frontend/src/pages/MarketPage.js
@@ -44,7 +44,7 @@ const MarketPage = () => {
     useEffect(() => {
         fetchListings(currentPage);
 
-        const socket = io(process.env.REACT_APP_API_URL || 'http://localhost:5000', {
+        const socket = io(process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000', {
             transports: ['websocket'],
         });
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,5 @@
 // src/utils/api.js
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
 
 export const fetchWithAuth = async (endpoint, options = {}) => {
     try {


### PR DESCRIPTION
## Summary
- rename `REACT_APP_API_URL` references to `REACT_APP_API_BASE_URL`
- keep NotificationDropdown importing `API_BASE_URL`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm start` (ensure dev server compiles)

------
https://chatgpt.com/codex/tasks/task_e_6855725719448330a6ee771cb2d8b4d2