### PR TITLE
Fix transaction timeout in offer acceptance

### DIFF
--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -290,6 +290,8 @@ router.put('/listings/:id/offers/:offerId/accept', protect, sensitiveLimiter, as
     await session.commitTransaction();
     session.endSession();
 
+    await marketService.finalizeOfferAcceptance(result);
+
     res.status(200).json({ message: 'Offer accepted, card transferred, and listing sold.' });
   } catch (error) {
     console.error('Error accepting offer:', error);


### PR DESCRIPTION
## Summary
- adjust acceptOffer so DB updates complete quickly
- create finalizeOfferAcceptance for notifications, XP, achievements
- call finalizeOfferAcceptance after committing transaction

## Testing
- `npm test` (fails: `Error: no test specified`)
- `npm test --silent` in `frontend` (fails: `react-scripts: not found`)


------
https://chatgpt.com/codex/tasks/task_e_6855971ce3548330ac8c702e3a642097