### PR TITLE
Fix card border scaling

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -535,7 +535,7 @@
 }
 
 .card-container.divine .card-border {
-    width: 300px;
+    width: 100%;
 }
 
 @keyframes divine-glow {


### PR DESCRIPTION
## Summary
- correct Divine card border width to scale with container

## Testing
- `npm test --silent`
- `cd backend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68559aece954833088da5fdccaa39303