### PR TITLE
Ensure consistent card artwork height

### DIFF
--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -462,7 +462,8 @@
     }
 
     .tp-card-item .card-artwork {
-        height: 43% !important;
+        /* Align card artwork sizing with BaseCard for consistency */
+        height: 48% !important;
         margin-top: 0 !important;
         border-width: 4px !important;
         border-radius: 6px !important;


### PR DESCRIPTION
## Summary
- fix mobile CSS that forced inconsistent image sizing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855a2cac33c8330829f18bdd97f16a5