### PR TITLE
Ensure consistent card artwork height

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -1,3 +1,7 @@
+:root {
+    --card-artwork-height: 48%;
+}
+
 /**************************************
  * Generic Card Styles (Layout Only)
  **************************************/
@@ -85,7 +89,7 @@
     justify-content: center;
     margin: 5px 0;
     margin-top: -10px;
-    height: 48%;
+    height: var(--card-artwork-height);
     overflow: hidden;
     border-radius: 10px;
     border: 6px solid #6f4e37;

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -462,7 +462,6 @@
     }
 
     .tp-card-item .card-artwork {
-        height: 43% !important;
         margin-top: 0 !important;
         border-width: 4px !important;
         border-radius: 6px !important;


### PR DESCRIPTION
## Summary
- standardize `.card-artwork` sizing across the app
- rely on a CSS custom property instead of page-specific overrides

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855a2cac33c8330829f18bdd97f16a5