### PR TITLE
Fix card image sizing

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -102,7 +102,7 @@
         display: block;
         width: 100%;
         height: 100%;
-        object-fit: contain;
+        object-fit: cover;
         object-position: center;
         border-radius: 10px;
         transition: filter 0.3s ease;
@@ -501,7 +501,7 @@
     position: absolute;
     top: 0; left: 0;
     width: 100%; height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     object-position: center;
     border-radius: 10px;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- fix card image panels so they always fill using `object-fit: cover`

## Testing
- `npm test` (backend, expected failure: no tests specified)
- `CI=true npm test -- --passWithNoTests` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_6855ac95436c833086a2a91bc77823e7