### PR TITLE
Fix card image sizing

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -266,6 +266,13 @@ const BaseCard = ({
                     className="grayscale"
                     draggable={false}
                     loading="lazy"
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                      objectPosition: 'center',
+                      display: 'block',
+                    }}
                   />
                   <img
                     src={image}
@@ -274,10 +281,29 @@ const BaseCard = ({
                     ref={invertRef}
                     draggable={false}
                     loading="lazy"
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                      objectPosition: 'center',
+                      display: 'block',
+                    }}
                   />
                 </>
               ) : (
-                <img src={image} alt={name} draggable={false} loading="lazy" />
+                <img
+                  src={image}
+                  alt={name}
+                  draggable={false}
+                  loading="lazy"
+                  style={{
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                    objectPosition: 'center',
+                    display: 'block',
+                  }}
+                />
               )}
 
             </div>

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -1,4 +1,6 @@
 :root {
+    --card-width: 300px;
+    --card-height: 450px;
     --card-artwork-height: 48%;
 }
 
@@ -6,9 +8,10 @@
  * Generic Card Styles (Layout Only)
  **************************************/
 .card-container {
-    width: 100%;
-    max-width: 300px;
+    width: var(--card-width);
+    height: var(--card-height);
     aspect-ratio: 2 / 3;
+    max-width: var(--card-width);
     border-radius: 15px;
     overflow: hidden;
     display: flex;
@@ -102,7 +105,7 @@
         display: block;
         width: 100%;
         height: 100%;
-        object-fit: contain;
+        object-fit: cover;
         object-position: center;
         border-radius: 10px;
         transition: filter 0.3s ease;
@@ -501,7 +504,7 @@
     position: absolute;
     top: 0; left: 0;
     width: 100%; height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     object-position: center;
     border-radius: 10px;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- ensure card containers default to 300x450
- keep artwork images covering their frame

## Testing
- `npm test` (backend, expected failure: no test specified)
- `CI=true npm test -- --passWithNoTests` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6855ac95436c833086a2a91bc77823e7