### PR TITLE
Implement responsive card scaling

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -411,7 +411,7 @@ const CollectionPage = ({
             </div>
 
             {/* Cards Grid (unchanged) */}
-            <div className="cp-cards-grid" style={{ "--card-scale": cardScale }}>
+            <div className="cp-cards-grid" style={{ "--user-card-scale": cardScale }}>
                 {filteredCards.length > 0 ? (
                     filteredCards.map((card) => {
                         const isFeatured = featuredCards.some((fc) => fc._id === card._id);

--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -280,7 +280,7 @@ const MarketListingDetails = () => {
                                     ))}
                                 </select>
                             </div>
-                            <div className="market-user-collection-grid" style={{ '--card-scale': cardScale }}>
+                            <div className="market-user-collection-grid" style={{ '--user-card-scale': cardScale }}>
                                 {filteredCollection.map((card) => {
                                     const isSelected = selectedOfferedCards.some(c => c._id === card._id);
                                     return (
@@ -305,7 +305,7 @@ const MarketListingDetails = () => {
 
                         <div className="market-selected-cards-panel">
                             <h3>Selected Cards for Offer</h3>
-                            <div className="market-selected-cards-grid" style={{ '--card-scale': cardScale }}>
+                            <div className="market-selected-cards-grid" style={{ '--user-card-scale': cardScale }}>
                                 {selectedOfferedCards.length > 0 ? (
                                     selectedOfferedCards.map((card) => (
                                         <div key={card._id} className="market-card-wrapper">
@@ -347,7 +347,7 @@ const MarketListingDetails = () => {
                             {offer.offeredCards && offer.offeredCards.length > 0 && (
                                 <div className="offered-cards">
                                     <strong>Offered Cards:</strong>
-                                    <div className="offered-cards-grid" style={{ '--card-scale': cardScale }}>
+                                    <div className="offered-cards-grid" style={{ '--user-card-scale': cardScale }}>
                                         {offer.offeredCards.map(card => (
                                             <div key={card._id || card.name} className="offered-card-item">
                                                 <BaseCard

--- a/frontend/src/pages/MarketPage.js
+++ b/frontend/src/pages/MarketPage.js
@@ -138,7 +138,7 @@ const MarketPage = () => {
                     <button className="create-listing-button">Create New Listing</button>
                 </Link>
             </div>
-            <div className="listings-grid" style={{ '--card-scale': cardScale }}>
+            <div className="listings-grid" style={{ '--user-card-scale': cardScale }}>
                 {sortedListings.length > 0 ? (
                     sortedListings.map((listing) => (
                         <div key={listing._id} className="listing-card">

--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -223,7 +223,7 @@ const navigate = useNavigate();
           {trade.offeredPacks > 0 && (
             <p className="pack-count">{trade.offeredPacks} packs</p>
           )}
-          <div className="card-grid" style={{ '--card-scale': cardScale }}>
+          <div className="card-grid" style={{ '--user-card-scale': cardScale }}>
             {trade.offeredItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard
@@ -243,7 +243,7 @@ const navigate = useNavigate();
           {trade.requestedPacks > 0 && (
             <p className="pack-count">{trade.requestedPacks} packs</p>
           )}
-          <div className="card-grid" style={{ '--card-scale': cardScale }}>
+          <div className="card-grid" style={{ '--user-card-scale': cardScale }}>
             {trade.requestedItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard

--- a/frontend/src/styles/AdminDashboardPage.css
+++ b/frontend/src/styles/AdminDashboardPage.css
@@ -296,7 +296,8 @@
 
 /* card-content forced 300x450 */
 .card-content {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     width: calc(100% / var(--card-scale));
     max-width: 300px;
     aspect-ratio: 2 / 3;

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -19,6 +19,31 @@
 
     --border-radius: 8px;
     --transition: all 0.3s ease;
+    --screen-card-scale: 1;
+}
+
+@media (max-width: 1200px) {
+    :root {
+        --screen-card-scale: 0.85;
+    }
+}
+
+@media (max-width: 992px) {
+    :root {
+        --screen-card-scale: 0.75;
+    }
+}
+
+@media (max-width: 768px) {
+    :root {
+        --screen-card-scale: 0.65;
+    }
+}
+
+@media (max-width: 480px) {
+    :root {
+        --screen-card-scale: 0.55;
+    }
 }
 
 *, *::before, *::after {

--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -140,15 +140,16 @@
 
 /* Grid layout for catalogue cards */
 .cata-grid {
-    --cata-card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
     gap: 30px;
     margin-bottom: 40px;
-    width: calc(100% / var(--cata-card-scale));
-    transform: scale(var(--cata-card-scale));
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
     transform-origin: top left;
 }
 
@@ -193,26 +194,3 @@
     left: 10px;
 }
 
-@media (max-width: 1200px) {
-    .cata-grid {
-        --cata-card-scale: 0.85;
-    }
-}
-
-@media (max-width: 992px) {
-    .cata-grid {
-        --cata-card-scale: 0.75;
-    }
-}
-
-@media (max-width: 768px) {
-    .cata-grid {
-        --cata-card-scale: 0.65;
-    }
-}
-
-@media (max-width: 480px) {
-    .cata-grid {
-        --cata-card-scale: 0.55;
-    }
-}

--- a/frontend/src/styles/CollectionPage.css
+++ b/frontend/src/styles/CollectionPage.css
@@ -263,6 +263,8 @@ body {
 
 /* Cards Grid Container */
 .cp-cards-grid {
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     gap: 1.5rem;
     background: var(--surface-darker);

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -115,7 +115,8 @@
 
 /* User Collection Grid */
 .market-user-collection-grid {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -152,7 +153,8 @@
     }
 
 .market-selected-cards-grid {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -219,7 +221,8 @@
 }
 
 .offered-cards-grid {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
@@ -239,34 +242,3 @@
     opacity: 1 !important;
 }
 
-@media (max-width: 1200px) {
-    .market-user-collection-grid,
-    .market-selected-cards-grid,
-    .offered-cards-grid {
-        --card-scale: 0.85;
-    }
-}
-
-@media (max-width: 992px) {
-    .market-user-collection-grid,
-    .market-selected-cards-grid,
-    .offered-cards-grid {
-        --card-scale: 0.75;
-    }
-}
-
-@media (max-width: 768px) {
-    .market-user-collection-grid,
-    .market-selected-cards-grid,
-    .offered-cards-grid {
-        --card-scale: 0.65;
-    }
-}
-
-@media (max-width: 480px) {
-    .market-user-collection-grid,
-    .market-selected-cards-grid,
-    .offered-cards-grid {
-        --card-scale: 0.55;
-    }
-}

--- a/frontend/src/styles/MarketPage.css
+++ b/frontend/src/styles/MarketPage.css
@@ -79,7 +79,8 @@
     }
 
 .listings-grid {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(348px, 1fr));
     gap: 2rem;

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -248,7 +248,8 @@ body {
   overflow-y: auto;
 }
 .card-grid {
-  --card-scale: 1;
+  --user-card-scale: 1;
+  --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
@@ -260,14 +261,12 @@ body {
 
 @media (max-width: 600px) {
   .card-grid {
-    --card-scale: 0.9;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
 @media (max-width: 400px) {
   .card-grid {
-    --card-scale: 0.8;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -237,7 +237,8 @@ body {
 
 /* Featured Cards Section */
 .featured-cards {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -257,18 +258,11 @@ body {
 @media (max-width: 768px) {
     .featured-cards {
         gap: 1rem;
-        --card-scale: 0.9;
     }
 }
 
 .featured-cards > * {
     flex: 1 1 250px;
-}
-
-@media (max-width: 480px) {
-    .featured-cards {
-        --card-scale: 0.8;
-    }
 }
 
 
@@ -285,7 +279,8 @@ body {
 }
 
 .favorite-card-display {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     justify-content: center;
     margin-bottom: 1rem;
@@ -294,17 +289,6 @@ body {
     transform-origin: top left;
 }
 
-@media (max-width: 768px) {
-    .favorite-card-display {
-        --card-scale: 0.9;
-    }
-}
-
-@media (max-width: 480px) {
-    .favorite-card-display {
-        --card-scale: 0.8;
-    }
-}
 
 .favorite-card-form {
     margin-top: 1rem;
@@ -439,7 +423,8 @@ body {
 }
 
 .user-listings {
-    --card-scale: 1;
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -450,17 +435,6 @@ body {
     transform-origin: top left;
 }
 
-@media (max-width: 768px) {
-    .user-listings {
-        --card-scale: 0.9;
-    }
-}
-
-@media (max-width: 480px) {
-    .user-listings {
-        --card-scale: 0.8;
-    }
-}
 
 .more-listings {
     margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- make screen-card-scale CSS variable to handle responsive scaling
- compute card scale using screen and user scales in all grids
- update slider pages to use --user-card-scale

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855c3a51650833090bb2d4ee9a2f6b2