### PR TITLE
Fix card scale on pending trades panel

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -212,7 +212,12 @@ const navigate = useNavigate();
   );
 
   const DetailPanel = ({ trade, isOutgoing, open }) => (
-    <aside className={`detail-panel${open ? ' open' : ''}`} role="dialog" aria-modal="true">
+    <aside
+      className={`detail-panel${open ? ' open' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      style={{ '--user-card-scale': cardScale }}
+    >
       <header>
         <h2>Trade Details</h2>
       </header>

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -198,6 +198,8 @@ body {
 .age { text-align: right; }
 
 .detail-panel {
+  --user-card-scale: 1;
+  --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
   position: fixed;
   top: 60px;
   right: 0;


### PR DESCRIPTION
## Summary
- add CSS custom properties to detail panel for card scaling
- apply `--user-card-scale` style on pending trades panel so cards scale like other pages

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6855dea549a483308e6a59b13536291d