### PR TITLE
Fix card scale on pending trades panel

### DIFF
--- a/frontend/src/pages/PendingTrades.js
+++ b/frontend/src/pages/PendingTrades.js
@@ -33,11 +33,6 @@ const PendingTrades = () => {
   const [openTrade, setOpenTrade] = useState(null);
 const [panelOpen, setPanelOpen] = useState(false);
 const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  const defaultCardScale = 1;
-  const [cardScale] = useState(() => {
-    const stored = localStorage.getItem('cardScale');
-    return stored !== null ? parseFloat(stored) : defaultCardScale;
-  });
 useEffect(() => {
   if (!panelOpen && openTrade) {
     const t = setTimeout(() => setOpenTrade(null), 300);
@@ -212,7 +207,11 @@ const navigate = useNavigate();
   );
 
   const DetailPanel = ({ trade, isOutgoing, open }) => (
-    <aside className={`detail-panel${open ? ' open' : ''}`} role="dialog" aria-modal="true">
+    <aside
+      className={`detail-panel${open ? ' open' : ''}`}
+      role="dialog"
+      aria-modal="true"
+    >
       <header>
         <h2>Trade Details</h2>
       </header>
@@ -223,7 +222,7 @@ const navigate = useNavigate();
           {trade.offeredPacks > 0 && (
             <p className="pack-count">{trade.offeredPacks} packs</p>
           )}
-          <div className="card-grid" style={{ '--user-card-scale': cardScale }}>
+          <div className="card-grid">
             {trade.offeredItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard
@@ -243,7 +242,7 @@ const navigate = useNavigate();
           {trade.requestedPacks > 0 && (
             <p className="pack-count">{trade.requestedPacks} packs</p>
           )}
-          <div className="card-grid" style={{ '--user-card-scale': cardScale }}>
+          <div className="card-grid">
             {trade.requestedItems.map((item) => (
               <div key={item._id} className="card-tile">
                 <BaseCard

--- a/frontend/src/styles/PendingTrades.css
+++ b/frontend/src/styles/PendingTrades.css
@@ -198,6 +198,7 @@ body {
 .age { text-align: right; }
 
 .detail-panel {
+  --card-scale: var(--screen-card-scale);
   position: fixed;
   top: 60px;
   right: 0;
@@ -248,8 +249,7 @@ body {
   overflow-y: auto;
 }
 .card-grid {
-  --user-card-scale: 1;
-  --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+  --card-scale: var(--screen-card-scale);
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;


### PR DESCRIPTION
## Summary
- show pending trade details with screen card scale only
- remove user card scale usage

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6855dea549a483308e6a59b13536291d