### PR TITLE
Improve glitch gradient effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After configuring the backend environment, seed the default card modifiers:
 node src/scripts/seedModifiers.js
 ```
 This seeds the **Negative**, **Glitch**, and **Prismatic** modifiers. The Glitch modifier now features
-dynamic gradient lines that react to cursor movement.
+vivid crossed gradient lines layered above the static noise. These lines track the cursor for a highly visible glitch effect.
 
 ### Frontend (`frontend/.env`)
 The frontend uses a small `.env` file:

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -702,14 +702,24 @@
     --glitch-y: 0px;
     --glitch-angle: 0deg;
     background:
-        repeating-linear-gradient(var(--glitch-angle), rgba(255,0,255,0.25) 0 2px, rgba(0,255,255,0.25) 2px 4px, transparent 4px 6px),
+        repeating-linear-gradient(calc(var(--glitch-angle) - 45deg), rgba(255,0,0,0.5) 0 3px, transparent 3px 7px),
+        repeating-linear-gradient(calc(var(--glitch-angle) + 45deg), rgba(0,0,255,0.5) 0 3px, transparent 3px 7px),
+        repeating-linear-gradient(calc(var(--glitch-angle) + 90deg), rgba(255,255,255,0.35) 0 2px, transparent 2px 6px),
+        repeating-linear-gradient(var(--glitch-angle), rgba(255,0,255,0.45) 0 3px, rgba(0,255,255,0.45) 3px 5px, transparent 5px 8px),
         url('../assets/textures/static.gif') center/cover;
-    background-blend-mode: overlay, color-burn;
+    background-size: 200% 200%, 200% 200%, 200% 200%, 200% 200%, cover;
+    background-position:
+        calc(50% + var(--glitch-x)) calc(50% + var(--glitch-y)),
+        calc(50% - var(--glitch-x)) calc(50% - var(--glitch-y)),
+        calc(50% + var(--glitch-y)) calc(50% + var(--glitch-x)),
+        calc(50% + var(--glitch-x)) calc(50% + var(--glitch-y)),
+        center;
+    background-blend-mode: screen, screen, overlay, overlay, color-burn;
     mix-blend-mode: color-dodge;
-    opacity: 0.6;
+    opacity: 0.7;
     animation: glitchShift 1s steps(2, end) infinite;
     transform: translate(var(--glitch-x), var(--glitch-y));
-    transition: transform 0.1s ease, opacity 0.1s ease;
+    transition: transform 0.1s ease, opacity 0.1s ease, background-position 0.1s ease;
 }
 
 .card-container:hover .glitch-overlay {


### PR DESCRIPTION
## Summary
- upgrade README description of the glitch modifier
- stack multiple crossed gradients for the glitch overlay
- move glitch gradients with cursor and intensify colors

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e9400a5c83309a44f578d3d04aca