### PR TITLE
Animate negative overlay

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -775,6 +775,16 @@
     mix-blend-mode: difference;
     pointer-events: none;
     z-index: 5;
+    animation: negativeCycle 4s ease-in-out infinite;
+}
+
+@keyframes negativeCycle {
+    0%, 100% {
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
 }
 
 /* Glitch text effect */


### PR DESCRIPTION
## Summary
- loop between normal and inverted colors with `negativeCycle` animation

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68572fb890b48330b310f834bae28964