### PR TITLE
Fix admin dashboard username sorting

### DIFF
--- a/frontend/src/pages/AdminDashboardPage.js
+++ b/frontend/src/pages/AdminDashboardPage.js
@@ -116,17 +116,30 @@ const AdminDashboardPage = ({ user }) => {
     };
 
     const sortedUsers = [...filteredUsers].sort((a, b) => {
-        if (sortColumn) {
-            const aValue = a[sortColumn];
-            const bValue = b[sortColumn];
+        if (!sortColumn) return 0;
 
-            if (aValue < bValue) {
-                return sortDirection === 'asc' ? -1 : 1;
-            }
-            if (aValue > bValue) {
-                return sortDirection === 'asc' ? 1 : -1;
-            }
+        const aValue = a[sortColumn];
+        const bValue = b[sortColumn];
+
+        if (sortColumn === 'username') {
+            return sortDirection === 'asc'
+                ? String(aValue).localeCompare(String(bValue), undefined, { sensitivity: 'base' })
+                : String(bValue).localeCompare(String(aValue), undefined, { sensitivity: 'base' });
         }
+
+        if (sortColumn === 'lastActive') {
+            const dateA = new Date(aValue);
+            const dateB = new Date(bValue);
+            return sortDirection === 'asc' ? dateA - dateB : dateB - dateA;
+        }
+
+        if (aValue < bValue) {
+            return sortDirection === 'asc' ? -1 : 1;
+        }
+        if (aValue > bValue) {
+            return sortDirection === 'asc' ? 1 : -1;
+        }
+
         return 0;
     });
 


### PR DESCRIPTION
## Summary
- fix alphabetical ordering on AdminDashboardPage by using `localeCompare`

## Testing
- `npm test` (fails: `react-scripts: not found`)
- `npm test` in backend (fails: `Error: no test specified`)


------
https://chatgpt.com/codex/tasks/task_e_6857d2c4602483309747525022717b43