### PR TITLE
Adjust tier 2 pack reward

### DIFF
--- a/backend/src/routes/twitchRoutes.js
+++ b/backend/src/routes/twitchRoutes.js
@@ -14,8 +14,9 @@ let TWITCH_REFRESH_TOKEN = process.env.TWITCH_REFRESH_TOKEN;
 const CHANNEL_POINTS_COST = parseInt(process.env.CHANNEL_POINTS_COST || '5000', 10);
 // Packs awarded for each subscription tier
 // Tier 3 subscriptions were previously awarded 20 packs, which was overly
-// generous. Both regular and gifted tier 3 subs now grant 5 packs instead.
-const tierPacks = { '1000': 1, '2000': 5, '3000': 5 };
+// generous. Both regular and gifted tier 3 subs now grant 5 packs.
+// Tier 2 subscriptions grant 3 packs to differentiate them from tier 3.
+const tierPacks = { '1000': 1, '2000': 3, '3000': 5 };
 
 if (!TWITCH_SECRET) {
     console.error('TWITCH_SECRET is not defined in the environment variables!');

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -71,7 +71,7 @@ const DashboardPage = () => {
                             <li>Earn 1 pack for your first login and signing into the app.</li>
                             <li>
                                 Earn packs when you subscribe: 1 pack for tier 1,
-                                5 packs for tier 2, and 5 packs for tier 3.
+                                3 packs for tier 2, and 5 packs for tier 3.
                             </li>
                             <li>
                                 Gifted subscriptions award packs to the gifter and


### PR DESCRIPTION
## Summary
- update backend logic so tier 2 subs give 3 packs
- update dashboard text describing sub pack rewards

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test --watchAll=false` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685838c073688330a58017705c279603