### PR TITLE
Fix market listing modifier validation

### DIFF
--- a/backend/src/models/MarketListing.js
+++ b/backend/src/models/MarketListing.js
@@ -8,7 +8,9 @@ const offerSchema = new mongoose.Schema({
     imageUrl: { type: String, required: true },
     rarity: { type: String, required: true },
     mintNumber: { type: Number, required: true },
-    flavorText: { type: String }
+    flavorText: { type: String },
+    // Optional modifier information for the offered card
+    modifier: { type: mongoose.Schema.Types.Mixed, default: null }
   }],
   offeredPacks: { type: Number, default: 0 },
   createdAt: { type: Date, default: Date.now },
@@ -22,7 +24,9 @@ const marketListingSchema = new mongoose.Schema({
     imageUrl: { type: String, required: true },
     rarity: { type: String, required: true },
     mintNumber: { type: Number, required: true },
-    flavorText: { type: String }
+    flavorText: { type: String },
+    // Include modifier details if present on the card being listed
+    modifier: { type: mongoose.Schema.Types.Mixed, default: null }
   },
   createdAt: { type: Date, default: Date.now },
   status: {

--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -18,7 +18,9 @@ router.post('/listings', protect, sensitiveLimiter, async (req, res) => {
             imageUrl: Joi.string().required(),
             rarity: Joi.string().required(),
             mintNumber: Joi.number().integer().min(0).required(),
-            flavorText: Joi.string().allow('', null)
+            flavorText: Joi.string().allow('', null),
+            // Modifier may be an ObjectId or populated object; allow any value
+            modifier: Joi.any().optional()
         });
 
         const { error } = cardSchema.validate(req.body.card);
@@ -168,7 +170,9 @@ router.post('/listings/:id/offers', protect, sensitiveLimiter, async (req, res) 
                     imageUrl: Joi.string().uri().required(),
                     rarity: Joi.string().required(),
                     mintNumber: Joi.number().integer().min(0).required(),
-                    flavorText: Joi.string().allow('', null)
+                    flavorText: Joi.string().allow('', null),
+                    // Optional modifier info for each offered card
+                    modifier: Joi.any().optional()
                 })
             ).required(),
             offeredPacks: Joi.number().min(0).required()


### PR DESCRIPTION
## Summary
- allow `modifier` field when creating market listings and offers
- store modifier info for listed and offered cards

## Testing
- `npm test` (fails: `Error: no test specified`)
- `npm test` in frontend (fails: `react-scripts: not found`)


------
https://chatgpt.com/codex/tasks/task_e_68587ea25f20833080e6f1436ecebb5c