### PR TITLE
Fix card scale slider by loading global CSS

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import Navbar from './components/Navbar';
 import LoadingSpinner from './components/LoadingSpinner';
 import Toast from './components/Toast';
 import 'normalize.css';
+import './styles/App.css';
 
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const CollectionPage = lazy(() => import('./pages/CollectionPage'));

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -12,7 +12,6 @@ import {
     fetchUserMarketListings,
 } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner';
-import '../styles/App.css';
 import '../styles/ProfilePage.css';
 import '../styles/MarketPage.css';
 import { rarities } from '../constants/rarities';


### PR DESCRIPTION
## Summary
- load main CSS variables in `App.js` so card scaling works without visiting profile page first
- remove duplicate import from `ProfilePage`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68587ec8df1c833097acac183062d896