### PR TITLE
Fix trade card scaling and expand slider range

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -376,7 +376,7 @@ const CollectionPage = ({
                             <label>Card Scale: </label>
                             <input
                                 type="range"
-                                min="0.5"
+                                min="0.1"
                                 max="2"
                                 step="0.05"
                                 value={cardScale}

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -30,6 +30,12 @@ const TradingPage = ({ userId }) => {
     const [rightSort, setRightSort] = useState("mintNumber");
     const [rightSortDir, setRightSortDir] = useState("asc");
 
+    const defaultCardScale = 1;
+    const [cardScale] = useState(() => {
+        const storedScale = localStorage.getItem("cardScale");
+        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
+    });
+
     // Fetch logged-in user data
     useEffect(() => {
         fetchWithAuth("/api/users/me")
@@ -337,7 +343,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid">
+                                    <div className="tp-cards-grid" style={{ '--user-card-scale': cardScale }}>
                                         {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir).map((card) => (
                                             <div
                                                 key={card._id}
@@ -385,7 +391,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid">
+                                    <div className="tp-cards-grid" style={{ '--user-card-scale': cardScale }}>
                                         {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir).map((card) => (
                                             <div
                                                 key={card._id}

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -196,6 +196,8 @@
 
 /* Cards Grid Container (using flex layout from Collection Page) */
 .tp-cards-grid {
+    --user-card-scale: 1;
+    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
     display: flex;
     gap: 1.5rem;
     background: var(--surface-darker);
@@ -207,7 +209,9 @@
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    width: 100%;
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
+    transform-origin: top left;
     box-sizing: border-box;
     min-width: 0;
 }


### PR DESCRIPTION
## Summary
- fix incorrect scaling in TradingPage when screen scale is applied
- read card scale from local storage in TradingPage
- lower scale slider minimum to 10% on CollectionPage

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685971e07118833085c2764a0889bc3c