### PR TITLE
Remove global card scaling overrides

### DIFF
--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -23,11 +23,7 @@ const MarketListingDetails = () => {
     const { id } = useParams();
     const navigate = useNavigate();
 
-    const defaultCardScale = 1;
-    const [cardScale] = useState(() => {
-        const storedScale = localStorage.getItem('cardScale');
-        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
-    });
+    // Card scale is fixed on this page
 
     const [listing, setListing] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -280,7 +276,7 @@ const MarketListingDetails = () => {
                                     ))}
                                 </select>
                             </div>
-                            <div className="market-user-collection-grid" style={{ '--user-card-scale': cardScale }}>
+                            <div className="market-user-collection-grid" style={{ '--user-card-scale': 1 }}>
                                 {filteredCollection.map((card) => {
                                     const isSelected = selectedOfferedCards.some(c => c._id === card._id);
                                     return (
@@ -305,7 +301,7 @@ const MarketListingDetails = () => {
 
                         <div className="market-selected-cards-panel">
                             <h3>Selected Cards for Offer</h3>
-                            <div className="market-selected-cards-grid" style={{ '--user-card-scale': cardScale }}>
+                            <div className="market-selected-cards-grid" style={{ '--user-card-scale': 1 }}>
                                 {selectedOfferedCards.length > 0 ? (
                                     selectedOfferedCards.map((card) => (
                                         <div key={card._id} className="market-card-wrapper">
@@ -347,7 +343,7 @@ const MarketListingDetails = () => {
                             {offer.offeredCards && offer.offeredCards.length > 0 && (
                                 <div className="offered-cards">
                                     <strong>Offered Cards:</strong>
-                                    <div className="offered-cards-grid" style={{ '--user-card-scale': cardScale }}>
+                                    <div className="offered-cards-grid" style={{ '--user-card-scale': 1 }}>
                                         {offer.offeredCards.map(card => (
                                             <div key={card._id || card.name} className="offered-card-item">
                                                 <BaseCard

--- a/frontend/src/pages/MarketPage.js
+++ b/frontend/src/pages/MarketPage.js
@@ -9,11 +9,8 @@ import '../styles/MarketPage.css';
 import { io } from 'socket.io-client';
 
 const MarketPage = () => {
-    const defaultCardScale = 1;
-    const [cardScale] = useState(() => {
-        const storedScale = localStorage.getItem('cardScale');
-        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
-    });
+    // Card scale on this page does not use the user's saved preference
+    // to ensure consistent layout across the market.
     const [listings, setListings] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -138,7 +135,7 @@ const MarketPage = () => {
                     <button className="create-listing-button">Create New Listing</button>
                 </Link>
             </div>
-            <div className="listings-grid" style={{ '--user-card-scale': cardScale }}>
+            <div className="listings-grid" style={{ '--user-card-scale': 1 }}>
                 {sortedListings.length > 0 ? (
                     sortedListings.map((listing) => (
                         <div key={listing._id} className="listing-card">

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -30,11 +30,7 @@ const TradingPage = ({ userId }) => {
     const [rightSort, setRightSort] = useState("mintNumber");
     const [rightSortDir, setRightSortDir] = useState("asc");
 
-    const defaultCardScale = 1;
-    const [cardScale] = useState(() => {
-        const storedScale = localStorage.getItem("cardScale");
-        return storedScale !== null ? parseFloat(storedScale) : defaultCardScale;
-    });
+    // This page ignores the user's collection scale preference
 
     // Fetch logged-in user data
     useEffect(() => {
@@ -343,7 +339,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid" style={{ '--user-card-scale': cardScale }}>
+                                    <div className="tp-cards-grid" style={{ '--user-card-scale': 1 }}>
                                         {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir).map((card) => (
                                             <div
                                                 key={card._id}
@@ -391,7 +387,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid" style={{ '--user-card-scale': cardScale }}>
+                                    <div className="tp-cards-grid" style={{ '--user-card-scale': 1 }}>
                                         {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir).map((card) => (
                                             <div
                                                 key={card._id}

--- a/frontend/src/styles/AdminDashboardPage.css
+++ b/frontend/src/styles/AdminDashboardPage.css
@@ -296,8 +296,7 @@
 
 /* card-content forced 300x450 */
 .card-content {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     width: calc(100% / var(--card-scale));
     max-width: 300px;
     aspect-ratio: 2 / 3;

--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -140,8 +140,7 @@
 
 /* Grid layout for catalogue cards */
 .cata-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -115,8 +115,7 @@
 
 /* User Collection Grid */
 .market-user-collection-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -153,8 +152,7 @@
     }
 
 .market-selected-cards-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1.25rem;
@@ -221,8 +219,7 @@
 }
 
 .offered-cards-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;

--- a/frontend/src/styles/MarketPage.css
+++ b/frontend/src/styles/MarketPage.css
@@ -79,8 +79,7 @@
     }
 
 .listings-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(348px, 1fr));
     gap: 2rem;

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -237,8 +237,7 @@ body {
 
 /* Featured Cards Section */
 .featured-cards {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -279,8 +278,7 @@ body {
 }
 
 .favorite-card-display {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     justify-content: center;
     margin-bottom: 1rem;
@@ -423,8 +421,7 @@ body {
 }
 
 .user-listings {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -196,8 +196,7 @@
 
 /* Cards Grid Container (using flex layout from Collection Page) */
 .tp-cards-grid {
-    --user-card-scale: 1;
-    --card-scale: calc(var(--screen-card-scale) * var(--user-card-scale));
+    --card-scale: var(--screen-card-scale);
     display: flex;
     gap: 1.5rem;
     background: var(--surface-darker);


### PR DESCRIPTION
## Summary
- drop `cardScale` localStorage retrieval from Market and Trading pages
- freeze card scale usage on market listing details
- remove `--user-card-scale` from most page styles
- default `--card-scale` to `var(--screen-card-scale)` for uniform scaling

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_685975d341c88330aeb0aefb673fcce2