### PR TITLE
Fix trade card layout on mobile

### DIFF
--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -339,7 +339,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid" style={{ '--user-card-scale': 1 }}>
+                                    <div className="tp-cards-grid">
                                         {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir).map((card) => (
                                             <div
                                                 key={card._id}
@@ -387,7 +387,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="desc">Descending</option>
                                         </select>
                                     </div>
-                                    <div className="tp-cards-grid" style={{ '--user-card-scale': 1 }}>
+                                    <div className="tp-cards-grid">
                                         {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir).map((card) => (
                                             <div
                                                 key={card._id}

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -196,7 +196,6 @@
 
 /* Cards Grid Container (using flex layout from Collection Page) */
 .tp-cards-grid {
-    --card-scale: var(--screen-card-scale);
     display: flex;
     gap: 1.5rem;
     background: var(--surface-darker);
@@ -208,9 +207,7 @@
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    width: calc(100% / var(--card-scale));
-    transform: scale(var(--card-scale));
-    transform-origin: top left;
+    width: 100%;
     box-sizing: border-box;
     min-width: 0;
 }


### PR DESCRIPTION
## Summary
- ensure trade page card grids don't scale the container
- remove unused inline user card scale styles

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(prints `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_685986e73538833098f822f1e0053353