### PR TITLE
Fix trading page scaling

### DIFF
--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -30,7 +30,7 @@ const TradingPage = ({ userId }) => {
     const [rightSort, setRightSort] = useState("mintNumber");
     const [rightSortDir, setRightSortDir] = useState("asc");
 
-    // This page ignores the user's collection scale preference
+    // Card scaling is handled responsively based on screen size
 
     // Fetch logged-in user data
     useEffect(() => {

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -187,11 +187,15 @@
 
 /* Horizontal Cards Row for Trade Preview */
 .tp-cards-horizontal {
+    --card-scale: var(--screen-card-scale);
     display: flex;
     gap: 1.5rem;
     padding: 1rem 0;
-    min-height: 250px;
+    min-height: calc(250px / var(--card-scale));
     overflow-x: visible;
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
+    transform-origin: top left;
 }
 
 /* Cards Grid Container (using flex layout from Collection Page) */
@@ -208,7 +212,9 @@
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    width: 100%;
+    width: calc(100% / var(--card-scale));
+    transform: scale(var(--card-scale));
+    transform-origin: top left;
     box-sizing: border-box;
     min-width: 0;
 }


### PR DESCRIPTION
## Summary
- scale trading cards horizontally to match screen scaling

## Testing
- `CI=true npm test --prefix frontend -- --passWithNoTests`
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859b303caa88330b7d04ff71071f32b