### PR TITLE
Fix cards grid container height scaling

### DIFF
--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -208,6 +208,7 @@
     border: 1px solid var(--border-dark);
     margin-bottom: 2rem;
     padding: 1rem;
+    min-height: calc(450px / var(--card-scale));
     overflow: hidden;
     flex-wrap: wrap;
     justify-content: center;


### PR DESCRIPTION
## Summary
- ensure the grid layout keeps its vertical space when scaled

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cdb42d148330b20c3234ba51b7d0