### PR TITLE
Fix cards grid container height scaling

### DIFF
--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -208,6 +208,7 @@
     border: 1px solid var(--border-dark);
     margin-bottom: 2rem;
     padding: 1rem;
+    min-height: calc(450px / var(--card-scale));
     overflow: hidden;
     flex-wrap: wrap;
     justify-content: center;
@@ -422,7 +423,7 @@
 @media (max-width: 768px) {
     .tp-cards-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
         gap: 1rem;
     }
 
@@ -452,7 +453,7 @@
 
 @media (max-width: 700px) {
     .tp-cards-grid {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
         gap: 0.75rem;
     }
     /* Mobile tweaks for card internals */
@@ -506,6 +507,7 @@
 
     .tp-cards-grid {
         gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the grid layout keeps its vertical space when scaled
- maintain card aspect ratio on narrow screens by aligning grid column width with card width

## Testing
- `npm test` *(fails: command not found)*
- `npm --prefix frontend test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cdb42d148330b20c3234ba51b7d0