### PR TITLE
Fix card scaling and panel layout

### DIFF
--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -118,8 +118,7 @@ const TradingPage = ({ userId }) => {
                         result = 0;
                 }
                 return sortDir === "asc" ? result : -result;
-            })
-            .slice(0, 15);
+            });
     };
 
     const handleSelectItem = (item, type) => {

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -42,7 +42,7 @@
 
 @media (max-width: 480px) {
     :root {
-        --screen-card-scale: 0.55;
+        --screen-card-scale: 0.3;
     }
 }
 

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -208,8 +208,7 @@
     border: 1px solid var(--border-dark);
     margin-bottom: 2rem;
     padding: 1rem;
-    min-height: calc(450px / var(--card-scale));
-    overflow: hidden;
+    overflow: visible;
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
@@ -424,6 +423,7 @@
     .tp-cards-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        justify-items: center;
         gap: 1rem;
     }
 
@@ -454,6 +454,7 @@
 @media (max-width: 700px) {
     .tp-cards-grid {
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        justify-items: center;
         gap: 0.75rem;
     }
     /* Mobile tweaks for card internals */
@@ -508,6 +509,7 @@
     .tp-cards-grid {
         gap: 0.5rem;
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        justify-items: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- update global card scale on very small screens
- prevent card grid from clipping inside TradingPage panels
- show full filtered collections on TradingPage

## Testing
- `npm test --silent` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_685aa497c0d083309a5ff7f4244a4da0