### PR TITLE
Improve page style consistency

### DIFF
--- a/frontend/src/styles/CataloguePage.css
+++ b/frontend/src/styles/CataloguePage.css
@@ -1,27 +1,58 @@
+:root {
+    --brand-primary: #db88db;
+    --brand-secondary: #88cddb;
+    --background-dark: #0a0a0a;
+    --surface-dark: #1a1a1a;
+    --surface-darker: #141414;
+    --text-primary: rgba(255, 255, 255, 0.95);
+    --border-dark: rgba(255, 255, 255, 0.12);
+    --border-radius: 16px;
+    --transition: all 0.3s ease;
+}
+
 /* Overall page container */
 .cata-page {
     padding: 40px 20px;
     max-width: 1800px;
     margin: 0 auto;
-    color: #f5f5dc;
-    background-color: #1a1a1a;
+    color: var(--text-primary);
+    background-color: var(--background-dark);
     min-height: 100vh;
 }
 
 .cata-page h1 {
     text-align: center;
-    margin-top: 100px;
-    margin-bottom: 10px;
-    font-size: 2.5rem;
-    font-weight: 700;
-    letter-spacing: 1px;
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    font-size: 2.25rem;
+    font-weight: 500;
+    position: relative;
+    color: var(--text-primary);
+}
+
+.cata-page h1::after {
+    content: '';
+    position: absolute;
+    bottom: -0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 2px;
+    background: var(--brand-primary);
+    border-radius: 2px;
 }
 
 .cata-description {
     text-align: center;
-    font-size: 1.2rem;
-    margin-bottom: 30px;
-    color: #f5f5dc;
+    font-size: 1.1rem;
+    margin: 0.5rem auto 1.5rem;
+    max-width: 800px;
+    color: var(--text-primary);
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    line-height: 1.6;
 }
 
 /* Container for filters arranged in a column */
@@ -45,10 +76,10 @@
     padding: 12px 16px;
     width: 100%;
     max-width: 500px;
-    border: none;
+    border: 1px solid var(--border-dark);
     border-radius: 8px;
-    background-color: #333;
-    color: #f5f5dc;
+    background-color: var(--surface-dark);
+    color: var(--text-primary);
     font-size: 1rem;
     box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.5);
     transition: box-shadow 0.3s ease;
@@ -119,15 +150,15 @@
 
 .cata-sort-box label {
     font-size: 1rem;
-    color: #f5f5dc;
+    color: var(--text-primary);
 }
 
 .cata-sort-box select {
     padding: 10px;
-    border: none;
+    border: 1px solid var(--border-dark);
     border-radius: 6px;
-    background-color: #333;
-    color: #f5f5dc;
+    background-color: var(--surface-dark);
+    color: var(--text-primary);
     font-size: 1rem;
     box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.5);
     transition: box-shadow 0.3s ease;

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -46,7 +46,8 @@
     border: 1px solid var(--border-dark);
     padding: 1rem;
     border-radius: var(--border-radius);
-    margin: 0.5rem 0 1rem;
+    margin: 0.5rem auto 1rem;
+    max-width: 800px;
     font-size: 1rem;
     line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- add global CSS variables to `CataloguePage.css`
- match trading page header style and info box width in catalogue page
- limit trading page info box width

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb901b0388330ac9dbd0b4879b838