### PR TITLE
Add card inspect feature

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage';
 import Navbar from './components/Navbar';
 import LoadingSpinner from './components/LoadingSpinner';
 import Toast from './components/Toast';
+import CardInspector from './components/CardInspector';
 import 'normalize.css';
 import './styles/App.css';
 
@@ -29,6 +30,7 @@ const App = () => {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
     const [toasts, setToasts] = useState([]);
+    const [inspectedCard, setInspectedCard] = useState(null);
 
     const showToast = (message, type = 'info') => {
         const id = Date.now();
@@ -41,6 +43,7 @@ const App = () => {
 
     useEffect(() => {
         window.showToast = showToast;
+        window.inspectCard = (card) => setInspectedCard(card);
     }, []);
 
     useEffect(() => {
@@ -150,6 +153,7 @@ const App = () => {
                     onClose={() => removeToast(toast.id)}
                 />
             ))}
+            <CardInspector card={inspectedCard} onClose={() => setInspectedCard(null)} />
         </>
     );
 };

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -13,6 +13,8 @@ const BaseCard = ({
   draggable,
   onDragStart,
   onDoubleClick,
+  onClick,
+  inspectOnClick = true,
   modifier,
 }) => {
   const cardRef = useRef(null);
@@ -199,6 +201,13 @@ const BaseCard = ({
     card.style.removeProperty('--glitch-y');
   };
 
+  const handleClick = (e) => {
+    if (onClick) onClick(e);
+    if (inspectOnClick && window.inspectCard) {
+      window.inspectCard({ name, image, description, rarity, mintNumber, modifier });
+    }
+  };
+
   return (
     <div
       ref={cardRef}
@@ -208,6 +217,7 @@ const BaseCard = ({
       draggable={draggable}
       onDragStart={e => draggable && onDragStart?.(e)}
       onDoubleClick={onDoubleClick}
+      onClick={handleClick}
       style={{
         ...(rarity.toLowerCase()==='divine' ? { backgroundImage: `url(${image})` } : {}),
         ...(modifierData?.css ? JSON.parse(modifierData.css) : {}),

--- a/frontend/src/components/CardInspector.js
+++ b/frontend/src/components/CardInspector.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import BaseCard from './BaseCard';
+import '../styles/CardInspector.css';
+
+const CardInspector = ({ card, onClose }) => {
+  if (!card) return null;
+  const { name, image, description, rarity, mintNumber, modifier } = card;
+  return (
+    <div className="card-inspector-overlay" onClick={onClose}>
+      <div className="card-inspector" onClick={(e) => e.stopPropagation()}>
+        <BaseCard
+          name={name}
+          image={image}
+          description={description}
+          rarity={rarity}
+          mintNumber={mintNumber}
+          modifier={modifier}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CardInspector;

--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -1,0 +1,34 @@
+.card-inspector-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.card-inspector {
+  animation: inspector-spin-in 0.5s ease forwards;
+  transform-style: preserve-3d;
+}
+
+.card-inspector .card-container {
+  --card-width: 420px;
+  --card-height: 630px;
+  margin: 0;
+}
+
+@keyframes inspector-spin-in {
+  from {
+    transform: perspective(1000px) rotateY(180deg) scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: perspective(1000px) rotateY(0deg) scale(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add CardInspector overlay component
- enable single-click inspect in BaseCard
- manage inspector state globally in App
- style the inspector with spin-in animation

## Testing
- `npm test --silent` in `frontend` *(fails: No tests found)*
- `npm test --silent` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c03a88e948330bbcdb0aadc2450aa