### PR TITLE
Improve inspect card scaling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage';
 import Navbar from './components/Navbar';
 import LoadingSpinner from './components/LoadingSpinner';
 import Toast from './components/Toast';
+import CardInspector from './components/CardInspector';
 import 'normalize.css';
 import './styles/App.css';
 
@@ -29,6 +30,7 @@ const App = () => {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
     const [toasts, setToasts] = useState([]);
+    const [inspectedCard, setInspectedCard] = useState(null);
 
     const showToast = (message, type = 'info') => {
         const id = Date.now();
@@ -41,6 +43,7 @@ const App = () => {
 
     useEffect(() => {
         window.showToast = showToast;
+        window.inspectCard = (card) => setInspectedCard(card);
     }, []);
 
     useEffect(() => {
@@ -150,6 +153,7 @@ const App = () => {
                     onClose={() => removeToast(toast.id)}
                 />
             ))}
+            <CardInspector card={inspectedCard} onClose={() => setInspectedCard(null)} />
         </>
     );
 };

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -13,6 +13,9 @@ const BaseCard = ({
   draggable,
   onDragStart,
   onDoubleClick,
+  onClick,
+  inspectOnClick = true,
+  interactive = true,
   modifier,
 }) => {
   const cardRef = useRef(null);
@@ -125,7 +128,7 @@ const BaseCard = ({
     const halfH = rect.height / 2;
     const rotateX = -((y - halfH) / 10);
     const rotateY = ((x - halfW) / 10);
-    card.style.transform = `perspective(700px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+    card.style.transform = `scale(var(--card-scale, 1)) perspective(700px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
 
     if (["rare","legendary","epic","mythic"].includes(rarity.toLowerCase())) {
       card.style.setProperty('--cursor-x', `${(x/rect.width)*100}%`);
@@ -177,7 +180,7 @@ const BaseCard = ({
   const handleMouseLeave = () => {
     const card = cardRef.current;
     if (card) {
-      card.style.transform = 'perspective(700px) rotateX(0deg) rotateY(0deg)';
+      card.style.transform = 'scale(var(--card-scale, 1)) perspective(700px) rotateX(0deg) rotateY(0deg)';
       card.style.removeProperty('--cursor-x');
       card.style.removeProperty('--cursor-y');
     }
@@ -199,15 +202,23 @@ const BaseCard = ({
     card.style.removeProperty('--glitch-y');
   };
 
+  const handleClick = (e) => {
+    if (onClick) onClick(e);
+    if (inspectOnClick && window.inspectCard) {
+      window.inspectCard({ name, image, description, rarity, mintNumber, modifier });
+    }
+  };
+
   return (
     <div
       ref={cardRef}
       className={`card-container ${rarity.toLowerCase()}`}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+      onMouseMove={interactive ? handleMouseMove : undefined}
+      onMouseLeave={interactive ? handleMouseLeave : undefined}
       draggable={draggable}
       onDragStart={e => draggable && onDragStart?.(e)}
       onDoubleClick={onDoubleClick}
+      onClick={handleClick}
       style={{
         ...(rarity.toLowerCase()==='divine' ? { backgroundImage: `url(${image})` } : {}),
         ...(modifierData?.css ? JSON.parse(modifierData.css) : {}),

--- a/frontend/src/components/CardInspector.js
+++ b/frontend/src/components/CardInspector.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import BaseCard from './BaseCard';
+import '../styles/CardInspector.css';
+
+const CardInspector = ({ card, onClose }) => {
+  if (!card) return null;
+  const { name, image, description, rarity, mintNumber, modifier } = card;
+  return (
+    <div className="card-inspector-overlay" onClick={onClose}>
+      <div className="card-inspector" onClick={(e) => e.stopPropagation()}>
+        <BaseCard
+          name={name}
+          image={image}
+          description={description}
+          rarity={rarity}
+          mintNumber={mintNumber}
+          modifier={modifier}
+          inspectOnClick={false}
+          interactive={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CardInspector;

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -9,6 +9,7 @@
  * Generic Card Styles (Layout Only)
  **************************************/
 .card-container {
+    --card-scale: 1;
     width: var(--card-width);
     height: var(--card-height);
     aspect-ratio: 2 / 3;

--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -1,0 +1,38 @@
+.card-inspector-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+
+.card-inspector {
+  --inspector-scale: 2;
+  --card-scale: calc(var(--screen-card-scale) * var(--inspector-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-inspector .card-container {
+  margin: 0;
+  animation: inspector-spin-in 0.5s ease forwards;
+  transform-style: preserve-3d;
+}
+
+@keyframes inspector-spin-in {
+  from {
+    transform: scale(var(--card-scale)) perspective(1000px) rotateY(180deg);
+    opacity: 0;
+  }
+  to {
+    transform: scale(var(--card-scale)) perspective(1000px) rotateY(0deg);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- update BaseCard to preserve scaling when hovered
- enable interaction in CardInspector
- define default `--card-scale` in CardComponent styles

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `npm test --silent --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c03a88e948330bbcdb0aadc2450aa