### PR TITLE
Improve inspector view responsiveness

### DIFF
--- a/frontend/src/components/__tests__/CardInspector.test.js
+++ b/frontend/src/components/__tests__/CardInspector.test.js
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import CardInspector from '../CardInspector';
+
+describe('CardInspector', () => {
+  it('renders inspector with scaling variables', () => {
+    const card = { name: 'Sample', image: 'test.png', description: 'desc', rarity: 'common', mintNumber: 1 };
+    const { container } = render(<CardInspector card={card} onClose={() => {}} />);
+    const inspector = container.querySelector('.card-inspector');
+    expect(inspector).toBeInTheDocument();
+    const styles = getComputedStyle(inspector);
+    expect(styles.getPropertyValue('--card-scale')).not.toBe('');
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -13,7 +13,10 @@
 
 
 .card-inspector {
-  --inspector-scale: 2;
+  /* Scale card up while keeping it within the viewport */
+  --fit-height: calc(90vh / (var(--card-height) * var(--screen-card-scale)));
+  --fit-width: calc(90vw / (var(--card-width) * var(--screen-card-scale)));
+  --inspector-scale: min(var(--fit-height), var(--fit-width));
   --card-scale: calc(var(--screen-card-scale) * var(--inspector-scale));
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- scale the inspected card relative to the viewport so it appears large on any device
- cover basic inspector behaviour with a simple test

## Testing
- `npm test` *(fails: missing script)*
- `cd frontend && npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c302183b8833081f4600bf5a1bf02