### PR TITLE
Fix inspector card scale

### DIFF
--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -25,6 +25,8 @@
 }
 
 .card-inspector .card-container {
+  /* Reapply the inspector scale inside the card element */
+  --card-scale: calc(var(--screen-card-scale) * min(2, var(--inspector-scale)));
   margin: 0;
   animation: inspector-spin-in 0.5s ease;
   transform-style: preserve-3d;


### PR DESCRIPTION
## Summary
- adjust CardInspector styles so `--card-scale` overrides the default value in BaseCard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_685d0e5119288330938e6044989a7175