### PR TITLE
Fix inspector card scale

### DIFF
--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -13,21 +13,54 @@
 
 
 .card-inspector {
-  /* Scale card up while keeping it within the viewport */
+  /* Base scale for inspected card */
   --fit-height: calc(90vh / (var(--card-height) * var(--screen-card-scale)));
   --fit-width: calc(90vw / (var(--card-width) * var(--screen-card-scale)));
-  --inspector-scale: min(var(--fit-height), var(--fit-width));
-  /* Double the inspected card size but clamp to available space */
-  --card-scale: calc(var(--screen-card-scale) * min(2, var(--inspector-scale)));
+  --inspector-scale-base: 1.7;
+  --inspector-scale: min(var(--inspector-scale-base), var(--fit-height), var(--fit-width));
+  --card-scale: var(--inspector-scale);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .card-inspector .card-container {
+  /* Reapply the inspector scale inside the card element */
+  --card-scale: var(--inspector-scale);
   margin: 0;
   animation: inspector-spin-in 0.5s ease;
   transform-style: preserve-3d;
+}
+
+/* Adjust inspected card scale for different screen widths */
+@media (max-width: 2560px) {
+  .card-inspector {
+    --inspector-scale-base: 1.7;
+  }
+}
+
+@media (max-width: 1920px) {
+  .card-inspector {
+    --inspector-scale-base: 1.5;
+  }
+}
+
+@media (max-width: 1440px) {
+  .card-inspector {
+    --inspector-scale-base: 1.3;
+  }
+}
+
+@media (max-width: 768px) {
+  .card-inspector {
+    --inspector-scale-base: 1.1;
+  }
+}
+
+@media (max-width: 300px) {
+  .card-inspector {
+    --inspector-scale-base: 0.9;
+  }
 }
 
 @keyframes inspector-spin-in {


### PR DESCRIPTION
## Summary
- adjust CardInspector styles so `--card-scale` overrides the default value in BaseCard
- add responsive scale values for CardInspector across screen sizes

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0e5119288330938e6044989a7175