### PR TITLE
Update CardInspector scaling

### DIFF
--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -16,9 +16,9 @@
   /* Scale card up while keeping it within the viewport */
   --fit-height: calc(90vh / (var(--card-height) * var(--screen-card-scale)));
   --fit-width: calc(90vw / (var(--card-width) * var(--screen-card-scale)));
-  --inspector-scale: min(var(--fit-height), var(--fit-width));
+  --inspector-scale: min(2, var(--fit-height), var(--fit-width));
   /* Double the inspected card size but clamp to available space */
-  --card-scale: calc(var(--screen-card-scale) * min(2, var(--inspector-scale)));
+  --card-scale: calc(var(--screen-card-scale) * var(--inspector-scale));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -28,6 +28,7 @@
   margin: 0;
   animation: inspector-spin-in 0.5s ease;
   transform-style: preserve-3d;
+  transform: scale(var(--card-scale));
 }
 
 @keyframes inspector-spin-in {


### PR DESCRIPTION
## Summary
- keep inspector scaling limited to screen
- compute card scale with `--inspector-scale`
- apply scale transform to inspected cards

## Testing
- `npm test -- --watchAll=false` *(fails: CardInspector test not passing)*

------
https://chatgpt.com/codex/tasks/task_e_685d2bfa54e88330a616b4adef461a20