### PR TITLE
Add spin animation for inspecting cards

### DIFF
--- a/frontend/src/components/CardInspector.js
+++ b/frontend/src/components/CardInspector.js
@@ -1,9 +1,12 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import BaseCard from './BaseCard';
 import '../styles/CardInspector.css';
 
+const ANIMATION_DURATION = 500; // ms
+
 const CardInspector = ({ card, onClose }) => {
   const inspectorRef = useRef(null);
+  const [closing, setClosing] = useState(false);
 
   useEffect(() => {
     if (!card) return;
@@ -24,12 +27,18 @@ const CardInspector = ({ card, onClose }) => {
     return () => window.removeEventListener('resize', updateScale);
   }, [card]);
 
+  const handleClose = () => {
+    if (closing) return;
+    setClosing(true);
+    setTimeout(onClose, ANIMATION_DURATION);
+  };
+
   if (!card) return null;
   const { name, image, description, rarity, mintNumber, modifier } = card;
   return (
-    <div className="card-inspector-overlay" onClick={onClose}>
+    <div className={`card-inspector-overlay${closing ? ' closing' : ''}`} onClick={handleClose}>
       <div
-        className="card-inspector"
+        className={`card-inspector${closing ? ' closing' : ''}`}
         ref={inspectorRef}
         onClick={(e) => e.stopPropagation()}
       >

--- a/frontend/src/components/__tests__/CardInspector.test.js
+++ b/frontend/src/components/__tests__/CardInspector.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import CardInspector from '../CardInspector';
 
 describe('CardInspector', () => {
@@ -8,5 +8,17 @@ describe('CardInspector', () => {
     const inspector = container.querySelector('.card-inspector');
     expect(inspector).not.toBeNull();
     expect(inspector.querySelector('.card-container')).not.toBeNull();
+  });
+
+  it('adds closing class when overlay is clicked', () => {
+    jest.useFakeTimers();
+    const card = { name: 'Sample', image: 'test.png', description: 'desc', rarity: 'common', mintNumber: 1 };
+    const onClose = jest.fn();
+    const { container } = render(<CardInspector card={card} onClose={onClose} />);
+    const overlay = container.querySelector('.card-inspector-overlay');
+    fireEvent.click(overlay);
+    expect(overlay.classList.contains('closing')).toBe(true);
+    jest.runAllTimers();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/styles/CardInspector.css
+++ b/frontend/src/styles/CardInspector.css
@@ -33,6 +33,14 @@
   transform: scale(var(--card-scale));
 }
 
+.card-inspector.closing .card-container {
+  animation: inspector-spin-out 0.5s ease forwards;
+}
+
+.card-inspector-overlay.closing {
+  animation: overlay-fade-out 0.5s ease forwards;
+}
+
 @keyframes inspector-spin-in {
   from {
     transform: scale(var(--card-scale)) perspective(1000px) rotateY(180deg);
@@ -41,5 +49,25 @@
   to {
     transform: scale(var(--card-scale)) perspective(1000px) rotateY(0deg);
     opacity: 1;
+  }
+}
+
+@keyframes inspector-spin-out {
+  from {
+    transform: scale(var(--card-scale)) perspective(1000px) rotateY(0deg);
+    opacity: 1;
+  }
+  to {
+    transform: scale(var(--card-scale)) perspective(1000px) rotateY(180deg);
+    opacity: 0;
+  }
+}
+
+@keyframes overlay-fade-out {
+  from {
+    background: rgba(0, 0, 0, 0.8);
+  }
+  to {
+    background: rgba(0, 0, 0, 0);
   }
 }


### PR DESCRIPTION
## Summary
- animate CardInspector open/close with spin transitions
- update CardInspector test for closing behaviour

## Testing
- `npm test --prefix frontend -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685d44faf9c4833084dda24343edac7c