### PR TITLE
Update acquired date on card trades and market exchanges

### DIFF
--- a/backend/README_trading_market.md
+++ b/backend/README_trading_market.md
@@ -76,6 +76,7 @@ This document details the **refactored trading and market system**, including:
     - Swaps packs accordingly
     - Transfers card ownership
     - Marks cards as `'available'`
+    - Updates `acquiredAt` timestamp on transferred cards
     - Cancels other pending trades/listings involving these cards
     - Notifies both users
   - If **rejected/cancelled**:
@@ -121,6 +122,7 @@ This document details the **refactored trading and market system**, including:
 - **Process:**
   - Transfers packs and card ownership
   - Marks card as `'available'`
+  - Updates `acquiredAt` timestamp on transferred cards
   - Deletes listing
   - Cancels other listings for the same card
   - Notifies buyer and seller

--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -157,6 +157,7 @@ const updateTradeStatus = async (req, res) => {
                     const cardObj = sender.cards.splice(index, 1)[0];
                     removeFromFeaturedCards(sender, cardObj._id);
                     cardObj.status = 'available';
+                    cardObj.acquiredAt = new Date();
                     recipient.cards.push(cardObj);
                 } else {
                     console.warn(`Offered card with ID ${card._id} not found in sender's collection.`);
@@ -169,6 +170,7 @@ const updateTradeStatus = async (req, res) => {
                     const cardObj = recipient.cards.splice(index, 1)[0];
                     removeFromFeaturedCards(recipient, cardObj._id);
                     cardObj.status = 'available';
+                    cardObj.acquiredAt = new Date();
                     sender.cards.push(cardObj);
                 } else {
                     console.warn(`Requested card with ID ${card._id} not found in recipient's collection.`);

--- a/backend/src/services/marketService.js
+++ b/backend/src/services/marketService.js
@@ -78,6 +78,7 @@ async function acceptOffer(listingId, offerId, userId, session) {
   const [cardToTransfer] = seller.cards.splice(cardIndexInSeller, 1);
   removeFromFeaturedCards(seller, cardToTransfer._id);
   cardToTransfer.status = 'available'; // Ensure status is set correctly before pushing
+  cardToTransfer.acquiredAt = new Date();
   buyer.cards.push(cardToTransfer);
   console.log('[Accept Offer Service] Listed card added to buyer locally.');
 
@@ -130,6 +131,7 @@ async function acceptOffer(listingId, offerId, userId, session) {
           const [removedCard] = buyer.cards.splice(i, 1);
           removeFromFeaturedCards(buyer, removedCard._id);
           removedCard.status = 'available'; // Set status back to available for the seller
+          removedCard.acquiredAt = new Date();
           cardsToGiveSeller.push(removedCard);
       }
   }


### PR DESCRIPTION
## Summary
- update `acquiredAt` whenever cards change owners in tradeController
- update `acquiredAt` when market listings transfer cards to new owners
- document that transfer operations refresh the acquisition timestamp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f14aa9ab08330977846a1cd25f37f