### PR TITLE
Improve epic card gradient

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -335,19 +335,19 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-image: linear-gradient(40deg, transparent 25%, rgba(255,69,0,0.25) 50%, transparent 75%), linear-gradient(40deg, transparent 30%, rgba(255,100,0,0.2) 50%, transparent 70%), linear-gradient(40deg, transparent 20%, rgba(255,140,0,0.15) 50%, transparent 80%), url('../assets/textures/subtle-sparkle.png'), url('../assets/textures/noise.png');
+        background-image: linear-gradient(40deg, transparent 25%, rgba(255,165,0,0.35) 50%, transparent 75%), linear-gradient(40deg, transparent 30%, rgba(255,215,0,0.3) 50%, transparent 70%), linear-gradient(40deg, transparent 20%, rgba(255,180,0,0.25) 50%, transparent 80%), url('../assets/textures/subtle-sparkle.png'), url('../assets/textures/noise.png');
         background-blend-mode: screen, screen, screen, overlay, multiply;
         background-size: 200% 100%, 200% 100%, 200% 100%, cover, cover;
         background-repeat: no-repeat;
         background-position: var(--cursor-x, 50%) 50%, var(--cursor-x, 50%) 50%, var(--cursor-x, 50%) 50%, center, center;
         pointer-events: none;
         z-index: 3;
-        opacity: 0.15;
+        opacity: 0.2;
         transition: opacity 0.3s ease, background-position 0.1s ease;
     }
 
     .card-container.epic:hover::after {
-        opacity: 0.3;
+        opacity: 0.4;
     }
 
     .card-container.epic::before {
@@ -361,12 +361,12 @@
         mix-blend-mode: screen;
         pointer-events: none;
         z-index: 4;
-        opacity: 0.2;
+        opacity: 0.25;
         transition: opacity 0.3s ease;
     }
 
     .card-container.epic:hover::before {
-        opacity: 0.5;
+        opacity: 0.6;
     }
 
 /**************************************


### PR DESCRIPTION
## Summary
- tweak epic overlay gradient for higher visibility
- strengthen sparkle overlay

## Testing
- `npm test` *(fails: No tests found)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863cc353dcc8330b6cee94540f772b2