### PR TITLE
Add tracking for trades and listings

### DIFF
--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -257,6 +257,8 @@ const updateTradeStatus = async (req, res) => {
             recipient.xp = (recipient.xp || 0) + 20;
             sender.level = Math.floor(sender.xp / 100) + 1;
             recipient.level = Math.floor(recipient.xp / 100) + 1;
+            sender.completedTrades = (sender.completedTrades || 0) + 1;
+            recipient.completedTrades = (recipient.completedTrades || 0) + 1;
             await sender.save({ session });
             await recipient.save({ session });
         }

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -59,6 +59,9 @@ const userSchema = new mongoose.Schema({
     // Gamification fields
     xp: { type: Number, default: 0 },
     level: { type: Number, default: 1 },
+    completedTrades: { type: Number, default: 0 },
+    createdListings: { type: Number, default: 0 },
+    completedListings: { type: Number, default: 0 },
     achievements: [
         {
             name: String,

--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -69,6 +69,10 @@ router.post('/listings', protect, sensitiveLimiter, async (req, res) => {
         );
 
         const savedListing = await newListing.save();
+        await User.updateOne(
+            { _id: req.user._id },
+            { $inc: { createdListings: 1 } }
+        );
         console.log('Saved listing card imageUrl:', savedListing.card?.imageUrl);
         logAudit('Market Listing Created', { listingId: savedListing._id, userId: req.user._id });
 

--- a/backend/src/services/marketService.js
+++ b/backend/src/services/marketService.js
@@ -235,6 +235,8 @@ async function finalizeOfferAcceptance({ seller, buyer, listing, offer }) {
   });
   console.log('[Accept Offer Service] Notifications created.');
 
+  seller.completedListings = (seller.completedListings || 0) + 1;
+
   console.log('[Accept Offer Service] Awarding XP.');
   seller.xp = (seller.xp || 0) + 15;
   buyer.xp = (buyer.xp || 0) + 15;


### PR DESCRIPTION
## Summary
- track completed trades and market activity in the user model
- bump completedTrades when trades are accepted
- count created listings and completed listings in market flows

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864e98409dc83309d99fe358868617a