### PR TITLE
Refactor achievements to use config

### DIFF
--- a/backend/src/helpers/achievementHelper.js
+++ b/backend/src/helpers/achievementHelper.js
@@ -1,57 +1,33 @@
+const achievementsConfig = require('../../../config/achievements');
+
 const checkAndGrantAchievements = async (user) => {
-  const achievements = [];
+  const newlyUnlocked = [];
+  const progressMap = {};
 
-  // Level milestones
-  if (user.level >= 1 && !user.achievements.some(a => a.name === 'Level 1')) {
-    achievements.push({ name: 'Level 1', description: 'Reached Level 1' });
-  }
-  if (user.level >= 5 && !user.achievements.some(a => a.name === 'Level 5')) {
-    achievements.push({ name: 'Level 5', description: 'Reached Level 5' });
-  }
-  if (user.level >= 10 && !user.achievements.some(a => a.name === 'Level 10')) {
-    achievements.push({ name: 'Level 10', description: 'Reached Level 10' });
-  }
-  if (user.level >= 20 && !user.achievements.some(a => a.name === 'Level 20')) {
-    achievements.push({ name: 'Level 20', description: 'Reached Level 20' });
-  }
-  if (user.level >= 50 && !user.achievements.some(a => a.name === 'Level 50')) {
-    achievements.push({ name: 'Level 50', description: 'Reached Level 50' });
-  }
+  for (const achievement of achievementsConfig) {
+    const progress = user[achievement.field] || 0;
+    const alreadyHas = user.achievements.some(a => a.name === achievement.name);
 
-  // Trades completed
-  if (user.completedTrades >= 10 && !user.achievements.some(a => a.name === 'Trader I')) {
-    achievements.push({ name: 'Trader I', description: 'Completed 10 trades' });
-  }
-  if (user.completedTrades >= 50 && !user.achievements.some(a => a.name === 'Trader II')) {
-    achievements.push({ name: 'Trader II', description: 'Completed 50 trades' });
+    progressMap[achievement.key] = {
+      current: progress,
+      threshold: achievement.threshold,
+      unlocked: progress >= achievement.threshold,
+    };
+
+    if (progress >= achievement.threshold && !alreadyHas) {
+      newlyUnlocked.push({ name: achievement.name, description: achievement.description });
+    }
   }
 
-  // Listings created
-  if (user.createdListings >= 10 && !user.achievements.some(a => a.name === 'Seller I')) {
-    achievements.push({ name: 'Seller I', description: 'Created 10 listings' });
-  }
-  if (user.createdListings >= 50 && !user.achievements.some(a => a.name === 'Seller II')) {
-    achievements.push({ name: 'Seller II', description: 'Created 50 listings' });
-  }
+  if (newlyUnlocked.length > 0) {
+    console.log(`Granting ${newlyUnlocked.length} achievements to user ${user.username}`);
+    newlyUnlocked.forEach(a => console.log(`- ${a.name}`));
 
-  // Packs opened (retroactive)
-  const openedPacksCount = user.openedPacks || 0;
-  if (openedPacksCount >= 10 && !user.achievements.some(a => a.name === 'Opener I')) {
-    achievements.push({ name: 'Opener I', description: 'Opened 10 packs' });
-  }
-  if (openedPacksCount >= 50 && !user.achievements.some(a => a.name === 'Opener II')) {
-    achievements.push({ name: 'Opener II', description: 'Opened 50 packs' });
-  }
-
-  if (achievements.length > 0) {
-    console.log(`Granting ${achievements.length} achievements to user ${user.username}`);
-    achievements.forEach(a => console.log(`- ${a.name}`));
-
-    user.achievements.push(...achievements.map(a => ({ ...a, dateEarned: new Date() })));
+    user.achievements.push(...newlyUnlocked.map(a => ({ ...a, dateEarned: new Date() })));
     await user.save();
 
     const { sendNotificationToUser } = require('../../notificationService');
-    for (const a of achievements) {
+    for (const a of newlyUnlocked) {
       sendNotificationToUser(user._id, {
         type: 'Achievement Unlocked',
         message: `You unlocked "${a.name}"!`,
@@ -61,6 +37,8 @@ const checkAndGrantAchievements = async (user) => {
   } else {
     console.log(`No new achievements for user ${user.username}`);
   }
+
+  return progressMap;
 };
 
 module.exports = { checkAndGrantAchievements };

--- a/config/achievements.js
+++ b/config/achievements.js
@@ -1,0 +1,17 @@
+module.exports = [
+  // Level based achievements
+  { key: 'LEVEL_1', name: 'Level 1', description: 'Reached Level 1', field: 'level', threshold: 1, reward: {} },
+  { key: 'LEVEL_5', name: 'Level 5', description: 'Reached Level 5', field: 'level', threshold: 5, reward: {} },
+  { key: 'LEVEL_10', name: 'Level 10', description: 'Reached Level 10', field: 'level', threshold: 10, reward: {} },
+  { key: 'LEVEL_20', name: 'Level 20', description: 'Reached Level 20', field: 'level', threshold: 20, reward: {} },
+  { key: 'LEVEL_50', name: 'Level 50', description: 'Reached Level 50', field: 'level', threshold: 50, reward: {} },
+  // Trade achievements
+  { key: 'TRADER_I', name: 'Trader I', description: 'Completed 10 trades', field: 'completedTrades', threshold: 10, reward: {} },
+  { key: 'TRADER_II', name: 'Trader II', description: 'Completed 50 trades', field: 'completedTrades', threshold: 50, reward: {} },
+  // Listing achievements
+  { key: 'SELLER_I', name: 'Seller I', description: 'Created 10 listings', field: 'createdListings', threshold: 10, reward: {} },
+  { key: 'SELLER_II', name: 'Seller II', description: 'Created 50 listings', field: 'createdListings', threshold: 50, reward: {} },
+  // Pack opening achievements
+  { key: 'OPENER_I', name: 'Opener I', description: 'Opened 10 packs', field: 'openedPacks', threshold: 10, reward: {} },
+  { key: 'OPENER_II', name: 'Opener II', description: 'Opened 50 packs', field: 'openedPacks', threshold: 50, reward: {} },
+];


### PR DESCRIPTION
## Summary
- add configuration for achievements
- compute achievements from this config in helper

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864e986392c8330a5809fe899f47136