### PR TITLE
Add loginCount tracking

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -62,6 +62,10 @@ exports.login = async (req, res) => {
             await user.save();
         }
 
+        // Increment login counter on successful login
+        user.loginCount = (user.loginCount || 0) + 1;
+        await user.save();
+
         // Generate JWT token
         const token = jwt.sign(
             { id: user._id, isAdmin: user.isAdmin },

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -8,7 +8,7 @@ const getUserProfile = async (req, res) => {
     try {
         const dbStart = process.hrtime();
         const user = await User.findById(req.user._id).select(
-            'username email isAdmin packs openedPacks featuredCards favoriteCard cards twitchProfilePic xp level achievements'
+            'username email isAdmin packs openedPacks loginCount featuredCards favoriteCard cards twitchProfilePic xp level achievements'
         ).lean();
         const dbEnd = process.hrtime(dbStart);
         console.log(`[PERF] [getUserProfile] DB query took ${dbEnd[0] * 1000 + dbEnd[1] / 1e6} ms`);
@@ -42,7 +42,7 @@ const getProfileByUsername = async (req, res) => {
 
         // Base fields returned for any profile lookup
         const baseFields =
-            'username isAdmin openedPacks featuredCards favoriteCard cards twitchProfilePic xp level achievements';
+            'username isAdmin openedPacks loginCount featuredCards favoriteCard cards twitchProfilePic xp level achievements';
 
         // Only include the email if the requester is viewing their own profile
         // or has admin privileges

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -55,6 +55,7 @@ const userSchema = new mongoose.Schema({
     firstLogin: { type: Boolean, default: false },
     isAdmin: { type: Boolean, default: false },
     lastActive: { type: Date }, // Last active in chat
+    loginCount: { type: Number, default: 0 },
 
     // Gamification fields
     xp: { type: Number, default: 0 },


### PR DESCRIPTION
## Summary
- add `loginCount` field to user model
- increment login counter on successful auth login
- expose login count through user profile APIs

## Testing
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864e98564848330b979dcaa14ede5af