### PR TITLE
Add achievements API and page

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -34,6 +34,7 @@ const marketRoutes = require('./src/routes/MarketRoutes');
 const notificationRoutes = require('./src/routes/notificationRoutes');
 const testNotificationRoutes = require('./src/routes/testNotificationRoutes');
 const adminRoutes = require('./src/routes/adminRoutes');
+const achievementRoutes = require('./src/routes/achievementRoutes');
 
 const app = express();
 app.set('trust proxy', 1);
@@ -97,6 +98,7 @@ app.use('/api/notifications', notificationRoutes);
 app.use('/api/test-notification', testNotificationRoutes); // Ensure this is correctly set up
 app.use('/api/admin', adminRoutes);
 app.use('/api/modifiers', require('./src/routes/modifierRoutes'));
+app.use('/api/achievements', achievementRoutes);
 
 
 // Default 404 handler (for any unmatched routes)

--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -1,0 +1,45 @@
+const User = require('../models/userModel');
+const Trade = require('../models/tradeModel');
+const MarketListing = require('../models/MarketListing');
+const ACHIEVEMENTS = require('../data/achievements');
+
+const getAchievements = async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id).lean();
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    // Count completed trades and created listings
+    const [tradeCount, listingCount] = await Promise.all([
+      Trade.countDocuments({
+        $or: [{ sender: user._id }, { recipient: user._id }],
+        status: 'accepted'
+      }),
+      MarketListing.countDocuments({ owner: user._id })
+    ]);
+
+    const achievements = ACHIEVEMENTS.map(a => {
+      let current = 0;
+      if (a.type === 'level') current = user.level || 0;
+      if (a.type === 'packs') current = user.openedPacks || 0;
+      if (a.type === 'trades') current = tradeCount;
+      if (a.type === 'listings') current = listingCount;
+      const achieved = current >= a.requirement;
+      return {
+        name: a.name,
+        description: a.description,
+        requirement: a.requirement,
+        current: Math.min(current, a.requirement),
+        achieved
+      };
+    });
+
+    res.json({ achievements });
+  } catch (err) {
+    console.error('Error fetching achievements:', err.message);
+    res.status(500).json({ message: 'Failed to fetch achievements' });
+  }
+};
+
+module.exports = { getAchievements };

--- a/backend/src/data/achievements.js
+++ b/backend/src/data/achievements.js
@@ -1,0 +1,13 @@
+module.exports = [
+  { name: 'Level 1', description: 'Reach Level 1', type: 'level', requirement: 1 },
+  { name: 'Level 5', description: 'Reach Level 5', type: 'level', requirement: 5 },
+  { name: 'Level 10', description: 'Reach Level 10', type: 'level', requirement: 10 },
+  { name: 'Level 20', description: 'Reach Level 20', type: 'level', requirement: 20 },
+  { name: 'Level 50', description: 'Reach Level 50', type: 'level', requirement: 50 },
+  { name: 'Trader I', description: 'Complete 10 trades', type: 'trades', requirement: 10 },
+  { name: 'Trader II', description: 'Complete 50 trades', type: 'trades', requirement: 50 },
+  { name: 'Seller I', description: 'Create 10 listings', type: 'listings', requirement: 10 },
+  { name: 'Seller II', description: 'Create 50 listings', type: 'listings', requirement: 50 },
+  { name: 'Opener I', description: 'Open 10 packs', type: 'packs', requirement: 10 },
+  { name: 'Opener II', description: 'Open 50 packs', type: 'packs', requirement: 50 }
+];

--- a/backend/src/routes/achievementRoutes.js
+++ b/backend/src/routes/achievementRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { protect } = require('../middleware/authMiddleware');
+const { getAchievements } = require('../controllers/achievementController');
+
+router.get('/', protect, getAchievements);
+
+module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,7 @@ const MarketListingDetails = lazy(() => import('./pages/MarketListingDetails'));
 const AdminActions = lazy(() => import('./pages/AdminActions'));
 const CardEditor = lazy(() => import('./components/CardEditor'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
+const AchievementsPage = lazy(() => import('./pages/AchievementsPage'));
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
 
@@ -130,6 +131,10 @@ const App = () => {
                     <Route
                         path="/trades/pending"
                         element={user ? <PendingTrades userId={user._id} /> : <Navigate to="/login" />}
+                    />
+                    <Route
+                        path="/achievements"
+                        element={user ? <AchievementsPage /> : <Navigate to="/login" />}
                     />
                     <Route
                         path="/admin/actions"

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -138,6 +138,15 @@ const Navbar = ({ isAdmin }) => {
                         Trading
                     </NavLink>
                 </li>
+                <li>
+                    <NavLink
+                        to="/achievements"
+                        className="nav-link"
+                        onClick={() => setMenuOpen(false)}
+                    >
+                        Achievements
+                    </NavLink>
+                </li>
                 {isAdmin && (
                     <>
                         <li>

--- a/frontend/src/pages/AchievementsPage.js
+++ b/frontend/src/pages/AchievementsPage.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAchievements } from '../utils/api';
+import '../styles/AchievementsPage.css';
+
+const AchievementsPage = () => {
+  const [achievements, setAchievements] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchAchievements();
+        setAchievements(data.achievements || []);
+      } catch (err) {
+        console.error('Failed to load achievements:', err);
+        setError('Failed to load achievements');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <div className="loading">Loading...</div>;
+  if (error) return <div className="error">{error}</div>;
+
+  return (
+    <div className="achievements-page">
+      <h1>Achievements</h1>
+      <div className="achievements-grid">
+        {achievements.map((ach, idx) => (
+          <div key={idx} className={`ach-tile ${ach.achieved ? 'achieved' : ''}`}>
+            <h3>{ach.name}</h3>
+            <p>{ach.description}</p>
+            <div className="ach-progress">
+              <div
+                className="ach-progress-bar"
+                style={{ width: `${(ach.current / ach.requirement) * 100}%` }}
+              ></div>
+            </div>
+            <div className="ach-progress-text">
+              {ach.current} / {ach.requirement}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AchievementsPage;

--- a/frontend/src/styles/AchievementsPage.css
+++ b/frontend/src/styles/AchievementsPage.css
@@ -1,0 +1,41 @@
+.achievements-page {
+  padding: 2rem;
+}
+
+.achievements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.ach-tile {
+  background: var(--surface-dark);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+  text-align: center;
+}
+
+.ach-tile.achieved {
+  border-color: var(--brand-secondary);
+}
+
+.ach-progress {
+  width: 100%;
+  height: 12px;
+  background: #333;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.ach-progress-bar {
+  height: 100%;
+  background: var(--brand-primary);
+  transition: width 0.3s ease;
+}
+
+.ach-progress-text {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -346,3 +346,14 @@ export const fetchUserMarketListings = async (userId, limit = 3) => {
         throw error;
     }
 };
+
+// Fetch achievements and progress for the logged in user
+export const fetchAchievements = async () => {
+    try {
+        const response = await fetchWithAuth('/api/achievements', { method: 'GET' });
+        return response;
+    } catch (error) {
+        console.error('[API] Error fetching achievements:', error.message);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- expose `/api/achievements` for progress on all achievements
- show achievements on new React page
- wire up route and navbar link

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e986f5808330bee2e491537b8e4d