### PR TITLE
Add admin achievements editing

### DIFF
--- a/backend/src/models/achievementModel.js
+++ b/backend/src/models/achievementModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const achievementSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  description: { type: String, default: '' },
+  threshold: { type: Number, default: 0 },
+  packRewards: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Pack' }],
+  cardRewards: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Card' }]
+}, { timestamps: true });
+
+module.exports = mongoose.model('Achievement', achievementSchema);

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -294,6 +294,7 @@ router.post('/grant-pack', protect, adminOnly, async (req, res) => {
 
 const Card = require('../models/cardModel');
 const Pack = require('../models/packModel');
+const Achievement = require('../models/achievementModel');
 
 router.get('/packs', async (req, res) => {
   try {
@@ -450,6 +451,52 @@ router.put('/cards/:cardId', protect, adminOnly, async (req, res) => {
   } catch (error) {
     console.error('Error updating card:', error);
     res.status(500).json({ message: 'Failed to update card' });
+  }
+});
+
+// ----- Achievement Management Endpoints -----
+router.get('/achievements', protect, adminOnly, async (req, res) => {
+  try {
+    const achievements = await Achievement.find();
+    res.json({ achievements });
+  } catch (err) {
+    console.error('Error fetching achievements:', err);
+    res.status(500).json({ message: 'Failed to fetch achievements' });
+  }
+});
+
+router.post('/achievements', protect, adminOnly, async (req, res) => {
+  try {
+    const achievement = new Achievement(req.body);
+    await achievement.save();
+    res.json({ achievement });
+  } catch (err) {
+    console.error('Error creating achievement:', err);
+    res.status(500).json({ message: 'Failed to create achievement' });
+  }
+});
+
+router.put('/achievements/:id', protect, adminOnly, async (req, res) => {
+  try {
+    const achievement = await Achievement.findById(req.params.id);
+    if (!achievement) return res.status(404).json({ message: 'Achievement not found' });
+    Object.assign(achievement, req.body);
+    await achievement.save();
+    res.json({ achievement });
+  } catch (err) {
+    console.error('Error updating achievement:', err);
+    res.status(500).json({ message: 'Failed to update achievement' });
+  }
+});
+
+router.delete('/achievements/:id', protect, adminOnly, async (req, res) => {
+  try {
+    const deleted = await Achievement.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ message: 'Achievement not found' });
+    res.json({ message: 'Achievement deleted' });
+  } catch (err) {
+    console.error('Error deleting achievement:', err);
+    res.status(500).json({ message: 'Failed to delete achievement' });
   }
 });
 


### PR DESCRIPTION
## Summary
- support an Achievement model
- CRUD endpoints under `/api/admin/achievements`
- admin UI for managing achievements

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test --silent` *(fails: react-scripts not found)*
- `cd ../backend && npm test --silent` *(shows "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6864e98765b88330bc55d58e5a7fd0d8