### PR TITLE
Expand achievements

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -2,6 +2,7 @@ const User = require('../models/userModel');
 const Trade = require('../models/tradeModel');
 const MarketListing = require('../models/MarketListing');
 const ACHIEVEMENTS = require('../data/achievements');
+const ALL_RARITIES = ['Basic','Common','Standard','Uncommon','Rare','Epic','Legendary','Mythic','Unique','Divine'];
 
 const getAchievements = async (req, res) => {
   try {
@@ -10,8 +11,8 @@ const getAchievements = async (req, res) => {
       return res.status(404).json({ message: 'User not found' });
     }
 
-    // Count completed trades and created listings
-    const [tradeCount, listingCount] = await Promise.all([
+  // Count completed trades and created listings
+  const [tradeCount, listingCount] = await Promise.all([
       Trade.countDocuments({
         $or: [{ sender: user._id }, { recipient: user._id }],
         status: 'accepted'
@@ -19,12 +20,28 @@ const getAchievements = async (req, res) => {
       MarketListing.countDocuments({ owner: user._id })
     ]);
 
+  const uniqueCards = new Set((user.cards || []).map(c => c.name)).size;
+
+  const byName = {};
+  (user.cards || []).forEach(c => {
+    if (!byName[c.name]) byName[c.name] = new Set();
+    byName[c.name].add(c.rarity);
+  });
+  let fullSets = 0;
+  for (const rarities of Object.values(byName)) {
+    if (ALL_RARITIES.every(r => rarities.has(r))) fullSets += 1;
+  }
+
     const achievements = ACHIEVEMENTS.map(a => {
       let current = 0;
       if (a.type === 'level') current = user.level || 0;
       if (a.type === 'packs') current = user.openedPacks || 0;
       if (a.type === 'trades') current = tradeCount;
       if (a.type === 'listings') current = listingCount;
+      if (a.type === 'sales') current = user.completedListings || 0;
+      if (a.type === 'uniqueCards') current = uniqueCards;
+      if (a.type === 'fullSets') current = fullSets;
+      if (a.type === 'logins') current = user.loginCount || 0;
       const achieved = current >= a.requirement;
       return {
         name: a.name,

--- a/backend/src/data/achievements.js
+++ b/backend/src/data/achievements.js
@@ -6,8 +6,21 @@ module.exports = [
   { name: 'Level 50', description: 'Reach Level 50', type: 'level', requirement: 50 },
   { name: 'Trader I', description: 'Complete 10 trades', type: 'trades', requirement: 10 },
   { name: 'Trader II', description: 'Complete 50 trades', type: 'trades', requirement: 50 },
+  { name: 'Trader III', description: 'Complete 100 trades', type: 'trades', requirement: 100 },
   { name: 'Seller I', description: 'Create 10 listings', type: 'listings', requirement: 10 },
   { name: 'Seller II', description: 'Create 50 listings', type: 'listings', requirement: 50 },
+  { name: 'Seller III', description: 'Create 100 listings', type: 'listings', requirement: 100 },
+  { name: 'Merchant I', description: 'Sell 10 cards on the market', type: 'sales', requirement: 10 },
+  { name: 'Merchant II', description: 'Sell 50 cards on the market', type: 'sales', requirement: 50 },
+  { name: 'Merchant III', description: 'Sell 100 cards on the market', type: 'sales', requirement: 100 },
   { name: 'Opener I', description: 'Open 10 packs', type: 'packs', requirement: 10 },
-  { name: 'Opener II', description: 'Open 50 packs', type: 'packs', requirement: 50 }
+  { name: 'Opener II', description: 'Open 50 packs', type: 'packs', requirement: 50 },
+  { name: 'Opener III', description: 'Open 100 packs', type: 'packs', requirement: 100 },
+  { name: 'Collector I', description: 'Own 10 unique cards', type: 'uniqueCards', requirement: 10 },
+  { name: 'Collector II', description: 'Own 50 unique cards', type: 'uniqueCards', requirement: 50 },
+  { name: 'Collector III', description: 'Own 100 unique cards', type: 'uniqueCards', requirement: 100 },
+  { name: 'Full Set Achiever', description: 'Own every rarity of a single card', type: 'fullSets', requirement: 1 },
+  { name: 'Regular I', description: 'Login 10 times', type: 'logins', requirement: 10 },
+  { name: 'Regular II', description: 'Login 50 times', type: 'logins', requirement: 50 },
+  { name: 'Regular III', description: 'Login 100 times', type: 'logins', requirement: 100 }
 ];

--- a/backend/src/helpers/achievementHelper.js
+++ b/backend/src/helpers/achievementHelper.js
@@ -1,11 +1,26 @@
 const achievementsConfig = require('../../../config/achievements');
+const ALL_RARITIES = ['Basic','Common','Standard','Uncommon','Rare','Epic','Legendary','Mythic','Unique','Divine'];
 
 const checkAndGrantAchievements = async (user) => {
   const newlyUnlocked = [];
   const progressMap = {};
 
+  const uniqueCards = new Set((user.cards || []).map(c => c.name)).size;
+  const setsByName = {};
+  (user.cards || []).forEach(card => {
+    if (!setsByName[card.name]) setsByName[card.name] = new Set();
+    setsByName[card.name].add(card.rarity);
+  });
+  let fullSets = 0;
+  for (const rarities of Object.values(setsByName)) {
+    if (ALL_RARITIES.every(r => rarities.has(r))) fullSets += 1;
+  }
+
   for (const achievement of achievementsConfig) {
-    const progress = user[achievement.field] || 0;
+    let progress = 0;
+    if (achievement.field === 'uniqueCards') progress = uniqueCards;
+    else if (achievement.field === 'fullSets') progress = fullSets;
+    else progress = user[achievement.field] || 0;
     const alreadyHas = user.achievements.some(a => a.name === achievement.name);
 
     progressMap[achievement.key] = {

--- a/config/achievements.js
+++ b/config/achievements.js
@@ -8,10 +8,26 @@ module.exports = [
   // Trade achievements
   { key: 'TRADER_I', name: 'Trader I', description: 'Completed 10 trades', field: 'completedTrades', threshold: 10, reward: {} },
   { key: 'TRADER_II', name: 'Trader II', description: 'Completed 50 trades', field: 'completedTrades', threshold: 50, reward: {} },
+  { key: 'TRADER_III', name: 'Trader III', description: 'Completed 100 trades', field: 'completedTrades', threshold: 100, reward: {} },
   // Listing achievements
   { key: 'SELLER_I', name: 'Seller I', description: 'Created 10 listings', field: 'createdListings', threshold: 10, reward: {} },
   { key: 'SELLER_II', name: 'Seller II', description: 'Created 50 listings', field: 'createdListings', threshold: 50, reward: {} },
+  { key: 'SELLER_III', name: 'Seller III', description: 'Created 100 listings', field: 'createdListings', threshold: 100, reward: {} },
+  // Market sales achievements
+  { key: 'MERCHANT_I', name: 'Merchant I', description: 'Sold 10 cards on the market', field: 'completedListings', threshold: 10, reward: {} },
+  { key: 'MERCHANT_II', name: 'Merchant II', description: 'Sold 50 cards on the market', field: 'completedListings', threshold: 50, reward: {} },
+  { key: 'MERCHANT_III', name: 'Merchant III', description: 'Sold 100 cards on the market', field: 'completedListings', threshold: 100, reward: {} },
   // Pack opening achievements
   { key: 'OPENER_I', name: 'Opener I', description: 'Opened 10 packs', field: 'openedPacks', threshold: 10, reward: {} },
   { key: 'OPENER_II', name: 'Opener II', description: 'Opened 50 packs', field: 'openedPacks', threshold: 50, reward: {} },
+  { key: 'OPENER_III', name: 'Opener III', description: 'Opened 100 packs', field: 'openedPacks', threshold: 100, reward: {} },
+  // Collection achievements
+  { key: 'COLLECTOR_I', name: 'Collector I', description: 'Own 10 unique cards', field: 'uniqueCards', threshold: 10, reward: {} },
+  { key: 'COLLECTOR_II', name: 'Collector II', description: 'Own 50 unique cards', field: 'uniqueCards', threshold: 50, reward: {} },
+  { key: 'COLLECTOR_III', name: 'Collector III', description: 'Own 100 unique cards', field: 'uniqueCards', threshold: 100, reward: {} },
+  { key: 'FULL_SET', name: 'Full Set Achiever', description: 'Own every rarity of a single card', field: 'fullSets', threshold: 1, reward: {} },
+  // Login milestones
+  { key: 'LOGIN_I', name: 'Regular I', description: 'Login 10 times', field: 'loginCount', threshold: 10, reward: {} },
+  { key: 'LOGIN_II', name: 'Regular II', description: 'Login 50 times', field: 'loginCount', threshold: 50, reward: {} },
+  { key: 'LOGIN_III', name: 'Regular III', description: 'Login 100 times', field: 'loginCount', threshold: 100, reward: {} },
 ];


### PR DESCRIPTION
## Summary
- extend achievements config with collector, merchant, opener III and login milestones
- mirror new achievements in backend data
- compute unique card and full set stats when retrieving achievements
- award achievements based on unique card and full set counts

## Testing
- `npm test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686506341b348330adc3f792de9170d4