### PR TITLE
Add achievement checks for admin pack opening

### DIFF
--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -161,6 +161,9 @@ const openPacksForUser = async (req, res) => {
         user.cards.push(...newCards);
         await user.save();
 
+        const { checkAndGrantAchievements } = require('../helpers/achievementHelper');
+        await checkAndGrantAchievements(user);
+
         res.status(200).json({ message: 'Pack opened successfully', newCards });
     } catch (error) {
         console.error('[openPacksForUser] Error:', error.message);


### PR DESCRIPTION
## Summary
- trigger `checkAndGrantAchievements` when admins open a user's pack

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865063496f483309e824ee30b87f66c