### PR TITLE
Fix listing achievements to track sold listings

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -10,14 +10,15 @@ const getAchievements = async (req, res) => {
       return res.status(404).json({ message: 'User not found' });
     }
 
-    // Count completed trades and created listings
-    const [tradeCount, listingCount] = await Promise.all([
-      Trade.countDocuments({
-        $or: [{ sender: user._id }, { recipient: user._id }],
-        status: 'accepted'
-      }),
-      MarketListing.countDocuments({ owner: user._id })
-    ]);
+    // Count completed trades and sold listings
+    const tradeCountPromise = Trade.countDocuments({
+      $or: [{ sender: user._id }, { recipient: user._id }],
+      status: 'accepted'
+    });
+
+    const [tradeCount] = await Promise.all([tradeCountPromise]);
+
+    const listingCount = user.completedListings || 0;
 
     const achievements = ACHIEVEMENTS.map(a => {
       let current = 0;

--- a/backend/src/data/achievements.js
+++ b/backend/src/data/achievements.js
@@ -6,8 +6,8 @@ module.exports = [
   { name: 'Level 50', description: 'Reach Level 50', type: 'level', requirement: 50 },
   { name: 'Trader I', description: 'Complete 10 trades', type: 'trades', requirement: 10 },
   { name: 'Trader II', description: 'Complete 50 trades', type: 'trades', requirement: 50 },
-  { name: 'Seller I', description: 'Create 10 listings', type: 'listings', requirement: 10 },
-  { name: 'Seller II', description: 'Create 50 listings', type: 'listings', requirement: 50 },
+  { name: 'Seller I', description: 'Sell 10 listings', type: 'listings', requirement: 10 },
+  { name: 'Seller II', description: 'Sell 50 listings', type: 'listings', requirement: 50 },
   { name: 'Opener I', description: 'Open 10 packs', type: 'packs', requirement: 10 },
   { name: 'Opener II', description: 'Open 50 packs', type: 'packs', requirement: 50 }
 ];

--- a/config/achievements.js
+++ b/config/achievements.js
@@ -9,8 +9,8 @@ module.exports = [
   { key: 'TRADER_I', name: 'Trader I', description: 'Completed 10 trades', field: 'completedTrades', threshold: 10, reward: {} },
   { key: 'TRADER_II', name: 'Trader II', description: 'Completed 50 trades', field: 'completedTrades', threshold: 50, reward: {} },
   // Listing achievements
-  { key: 'SELLER_I', name: 'Seller I', description: 'Created 10 listings', field: 'createdListings', threshold: 10, reward: {} },
-  { key: 'SELLER_II', name: 'Seller II', description: 'Created 50 listings', field: 'createdListings', threshold: 50, reward: {} },
+  { key: 'SELLER_I', name: 'Seller I', description: 'Sold 10 listings', field: 'completedListings', threshold: 10, reward: {} },
+  { key: 'SELLER_II', name: 'Seller II', description: 'Sold 50 listings', field: 'completedListings', threshold: 50, reward: {} },
   // Pack opening achievements
   { key: 'OPENER_I', name: 'Opener I', description: 'Opened 10 packs', field: 'openedPacks', threshold: 10, reward: {} },
   { key: 'OPENER_II', name: 'Opener II', description: 'Opened 50 packs', field: 'openedPacks', threshold: 50, reward: {} },

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -208,8 +208,8 @@ const ProfilePage = () => {
                         { name: 'Level 50', description: 'Reached Level 50' },
                         { name: 'Trader I', description: 'Completed 10 trades' },
                         { name: 'Trader II', description: 'Completed 50 trades' },
-                        { name: 'Seller I', description: 'Created 10 listings' },
-                        { name: 'Seller II', description: 'Created 50 listings' },
+                        { name: 'Seller I', description: 'Sold 10 listings' },
+                        { name: 'Seller II', description: 'Sold 50 listings' },
                         { name: 'Opener I', description: 'Opened 10 packs' },
                         { name: 'Opener II', description: 'Opened 50 packs' },
                     ].map((ach, idx) => {


### PR DESCRIPTION
## Summary
- align Seller achievements with sold listings
- update achievements list to use `completedListings`
- update achievements controller to read `completedListings` count
- adjust profile page default achievements

## Testing
- `npm test` within `frontend` *(fails: react-scripts not found)*
- `npm test` within `backend`

------
https://chatgpt.com/codex/tasks/task_e_68650635dbdc8330b27f55954d32cd2b