### PR TITLE
Update achievement reward handling

### DIFF
--- a/backend/src/models/achievementModel.js
+++ b/backend/src/models/achievementModel.js
@@ -4,8 +4,8 @@ const achievementSchema = new mongoose.Schema({
   name: { type: String, required: true, unique: true },
   description: { type: String, default: '' },
   threshold: { type: Number, default: 0 },
-  packRewards: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Pack' }],
-  cardRewards: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Card' }]
+  packs: { type: Number, default: 0 },
+  card: { type: mongoose.Schema.Types.ObjectId, ref: 'Card', default: null }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Achievement', achievementSchema);

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -467,7 +467,14 @@ router.get('/achievements', protect, adminOnly, async (req, res) => {
 
 router.post('/achievements', protect, adminOnly, async (req, res) => {
   try {
-    const achievement = new Achievement(req.body);
+    const { name, description, threshold, packs, card } = req.body;
+    const achievement = new Achievement({
+      name,
+      description,
+      threshold: Number(threshold) || 0,
+      packs: Number(packs) || 0,
+      card: card || null,
+    });
     await achievement.save();
     res.json({ achievement });
   } catch (err) {
@@ -480,7 +487,14 @@ router.put('/achievements/:id', protect, adminOnly, async (req, res) => {
   try {
     const achievement = await Achievement.findById(req.params.id);
     if (!achievement) return res.status(404).json({ message: 'Achievement not found' });
-    Object.assign(achievement, req.body);
+
+    const { name, description, threshold, packs, card } = req.body;
+    achievement.name = name;
+    achievement.description = description;
+    achievement.threshold = Number(threshold) || 0;
+    achievement.packs = Number(packs) || 0;
+    achievement.card = card || null;
+
     await achievement.save();
     res.json({ achievement });
   } catch (err) {


### PR DESCRIPTION
## Summary
- adjust achievement model for single card and pack quantities
- update admin routes to accept new reward structure
- implement card autocomplete and pack quantity inputs in AdminActions page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686506371e7c83309d2dd32a25658908