### PR TITLE
Expose achievement earned date

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -26,12 +26,14 @@ const getAchievements = async (req, res) => {
       if (a.type === 'trades') current = tradeCount;
       if (a.type === 'listings') current = listingCount;
       const achieved = current >= a.requirement;
+      const userAch = user.achievements?.find(ua => ua.name === a.name);
       return {
         name: a.name,
         description: a.description,
         requirement: a.requirement,
         current: Math.min(current, a.requirement),
-        achieved
+        achieved,
+        ...(userAch ? { dateEarned: userAch.dateEarned } : {})
       };
     });
 

--- a/frontend/src/pages/AchievementsPage.js
+++ b/frontend/src/pages/AchievementsPage.js
@@ -30,18 +30,26 @@ const AchievementsPage = () => {
       <h1>Achievements</h1>
       <div className="achievements-grid">
         {achievements.map((ach, idx) => (
-          <div key={idx} className={`ach-tile ${ach.achieved ? 'achieved' : ''}`}>
+          <div key={idx} className={`ach-tile ${ach.achieved ? 'achieved' : ''}`}> 
             <h3>{ach.name}</h3>
             <p>{ach.description}</p>
-            <div className="ach-progress">
-              <div
-                className="ach-progress-bar"
-                style={{ width: `${(ach.current / ach.requirement) * 100}%` }}
-              ></div>
-            </div>
-            <div className="ach-progress-text">
-              {ach.current} / {ach.requirement}
-            </div>
+            {ach.achieved ? (
+              <div className="ach-earned">
+                Achieved on {new Date(ach.dateEarned).toLocaleDateString()}
+              </div>
+            ) : (
+              <>
+                <div className="ach-progress">
+                  <div
+                    className="ach-progress-bar"
+                    style={{ width: `${(ach.current / ach.requirement) * 100}%` }}
+                  ></div>
+                </div>
+                <div className="ach-progress-text">
+                  {ach.current} / {ach.requirement}
+                </div>
+              </>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/styles/AchievementsPage.css
+++ b/frontend/src/styles/AchievementsPage.css
@@ -39,3 +39,9 @@
   margin-top: 0.25rem;
   font-size: 0.9rem;
 }
+
+.ach-earned {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--brand-secondary);
+}


### PR DESCRIPTION
## Summary
- include achievement `dateEarned` when fetching achievements
- display the date earned instead of the progress bar on the achievements page
- add basic styling for the achievement earned label

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865063b473c8330a76a835873c6d3a5