### PR TITLE
Add claimable achievements

### DIFF
--- a/backend/src/helpers/achievementHelper.js
+++ b/backend/src/helpers/achievementHelper.js
@@ -1,5 +1,4 @@
 const achievementsConfig = require('../../../config/achievements');
-const { generateCardWithProbability } = require('./cardHelpers');
 const ALL_RARITIES = ['Basic','Common','Standard','Uncommon','Rare','Epic','Legendary','Mythic','Unique','Divine'];
 
 const checkAndGrantAchievements = async (user) => {
@@ -43,27 +42,23 @@ const checkAndGrantAchievements = async (user) => {
     console.log(`Granting ${newlyUnlocked.length} achievements to user ${user.username}`);
     newlyUnlocked.forEach(a => console.log(`- ${a.name}`));
 
-    for (const a of newlyUnlocked) {
-      if (a.reward && a.reward.packs) {
-        user.packs = (user.packs || 0) + a.reward.packs;
-      }
-      if (a.reward && a.reward.card) {
-        const newCard = await generateCardWithProbability();
-        if (newCard) {
-          user.cards.push(newCard);
-        }
-      }
-    }
-
-    user.achievements.push(...newlyUnlocked.map(a => ({ name: a.name, description: a.description, dateEarned: new Date() })));
+    user.achievements.push(
+      ...newlyUnlocked.map(a => ({
+        name: a.name,
+        description: a.description,
+        reward: a.reward || {},
+        claimed: false,
+        dateEarned: new Date(),
+      }))
+    );
     await user.save();
 
     const { sendNotificationToUser } = require('../../notificationService');
     for (const a of newlyUnlocked) {
       sendNotificationToUser(user._id, {
         type: 'Achievement Unlocked',
-        message: `You unlocked "${a.name}"!`,
-        link: '/profile',
+        message: `You unlocked "${a.name}"! Claim your reward on the Achievements page.`,
+        link: '/achievements',
       });
     }
   } else {

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -67,6 +67,11 @@ const userSchema = new mongoose.Schema({
         {
             name: String,
             description: String,
+            reward: {
+                packs: { type: Number, default: 0 },
+                card: { type: Boolean, default: false },
+            },
+            claimed: { type: Boolean, default: false },
             dateEarned: { type: Date, default: Date.now }
         }
     ]

--- a/backend/src/routes/achievementRoutes.js
+++ b/backend/src/routes/achievementRoutes.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const { protect } = require('../middleware/authMiddleware');
-const { getAchievements } = require('../controllers/achievementController');
+const { getAchievements, claimAchievementReward } = require('../controllers/achievementController');
 
 router.get('/', protect, getAchievements);
+router.post('/claim', protect, claimAchievementReward);
 
 module.exports = router;

--- a/frontend/src/styles/AchievementsPage.css
+++ b/frontend/src/styles/AchievementsPage.css
@@ -20,6 +20,17 @@
   border-color: var(--brand-secondary);
 }
 
+.ach-tile.claimable {
+  cursor: pointer;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255,255,255,0.5); }
+  70% { box-shadow: 0 0 0 10px rgba(255,255,255,0); }
+  100% { box-shadow: 0 0 0 0 rgba(255,255,255,0); }
+}
+
 .ach-progress {
   width: 100%;
   height: 12px;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -357,3 +357,16 @@ export const fetchAchievements = async () => {
         throw error;
     }
 };
+
+// Claim a reward for a specific achievement name
+export const claimAchievement = async (name) => {
+    try {
+        return await fetchWithAuth('/api/achievements/claim', {
+            method: 'POST',
+            body: JSON.stringify({ name }),
+        });
+    } catch (error) {
+        console.error('[API] Error claiming achievement reward:', error.message);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- let users claim achievement rewards instead of auto-granting
- store reward details and claimed flag on each achievement
- provide API to claim rewards
- make achievement tiles clickable when claimable and show reward overlay

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68655d2ede44833090a989573ec3a3b5