### PR TITLE
Show received achievement card + fix acquisition date

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -94,6 +94,7 @@ const claimAchievementReward = async (req, res) => {
     if (reward.card) {
       rewardCard = await generateCardWithProbability();
       if (rewardCard) {
+        rewardCard.acquiredAt = new Date();
         user.cards.push(rewardCard);
       }
     }

--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -56,6 +56,7 @@ const openPack = async (req, res) => {
             newCard.name = `${prefix} ${newCard.name}`;
         }
 
+        newCard.acquiredAt = new Date();
         user.cards.push(newCard);
         user.openedPacks += 1;
         user.packs -= 1;
@@ -149,6 +150,7 @@ const openPacksForUser = async (req, res) => {
                 const prefix = mod.name === 'Glitch' ? 'Glitched' : mod.name;
                 newCard.name = `${prefix} ${newCard.name}`;
             }
+            newCard.acquiredAt = new Date();
         }
 
         user.packs -= 1;

--- a/frontend/src/pages/AchievementsPage.js
+++ b/frontend/src/pages/AchievementsPage.js
@@ -29,7 +29,15 @@ const AchievementsPage = () => {
     try {
       const res = await claimAchievement(ach.name);
       if (res.card) {
-        window.inspectCard(res.card);
+        const { name, imageUrl, flavorText, rarity, mintNumber, modifier } = res.card;
+        window.inspectCard({
+          name,
+          image: imageUrl,
+          description: flavorText,
+          rarity,
+          mintNumber,
+          modifier,
+        });
       }
       window.showToast('Reward claimed!', 'success');
       setAchievements((prev) =>


### PR DESCRIPTION
## Summary
- show inspected card when claiming an achievement reward
- store `acquiredAt` timestamp when rewards or packs grant cards

## Testing
- `npm test` (backend, fails: Error: no test specified)
- `npm test -- --watchAll=false` (frontend, fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_6865a27816288330b003b03edc5aab81