### PR TITLE
Fix achievements grid responsiveness

### DIFF
--- a/frontend/src/styles/AchievementsPage.css
+++ b/frontend/src/styles/AchievementsPage.css
@@ -46,9 +46,16 @@
 }
 
 .achievements-grid {
+  width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .achievements-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
 }
 
 .ach-tile {


### PR DESCRIPTION
## Summary
- make achievements grid full width
- adjust grid columns for smaller screens

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_68664c642d0c83308e27785112122cb1