### PR TITLE
Add spinner when claiming achievements

### DIFF
--- a/frontend/src/pages/AchievementsPage.js
+++ b/frontend/src/pages/AchievementsPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchAchievements, claimAchievement } from '../utils/api';
+import LoadingSpinner from '../components/LoadingSpinner';
 import '../styles/AchievementsPage.css';
 
 const AchievementsPage = () => {
@@ -51,11 +52,12 @@ const AchievementsPage = () => {
     }
   };
 
-  if (loading) return <div className="loading">Loading...</div>;
+  if (loading) return <LoadingSpinner />;
   if (error) return <div className="error">{error}</div>;
 
   return (
     <div className="achievements-page">
+      {claiming && <LoadingSpinner />}
       <h1>Achievements</h1>
       <p className="ach-description">
         Earn achievements by completing various tasks. Click on an unlocked


### PR DESCRIPTION
## Summary
- show loading spinner while fetching achievements and while reward is being claimed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867ce2cf62c833098739e0cea522356