### PR TITLE
Default sort by acquisition date

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -56,8 +56,8 @@ const CollectionPage = ({
     // Filter states
     const [search, setSearch] = useState('');
     const [rarityFilter, setRarityFilter] = useState('');
-    const [sortOption, setSortOption] = useState('');
-    const [order, setOrder] = useState('asc');
+    const [sortOption, setSortOption] = useState('acquiredAt');
+    const [order, setOrder] = useState('desc');
 
     // Featured states
     const [featuredCards, setFeaturedCards] = useState([]);

--- a/frontend/src/pages/CreateListingPage.js
+++ b/frontend/src/pages/CreateListingPage.js
@@ -32,8 +32,8 @@ const CreateListingPage = () => {
     // Filter/sort states
     const [search, setSearch] = useState('');
     const [rarityFilter, setRarityFilter] = useState('');
-    const [sortOption, setSortOption] = useState('name');
-    const [sortOrder, setSortOrder] = useState('asc');
+    const [sortOption, setSortOption] = useState('acquiredAt');
+    const [sortOrder, setSortOrder] = useState('desc');
 
     const navigate = useNavigate();
 

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -23,12 +23,12 @@ const TradingPage = ({ userId }) => {
 
     const [leftSearch, setLeftSearch] = useState("");
     const [leftRarity, setLeftRarity] = useState("");
-    const [leftSort, setLeftSort] = useState("mintNumber");
-    const [leftSortDir, setLeftSortDir] = useState("asc");
+    const [leftSort, setLeftSort] = useState("acquiredAt");
+    const [leftSortDir, setLeftSortDir] = useState("desc");
     const [rightSearch, setRightSearch] = useState("");
     const [rightRarity, setRightRarity] = useState("");
-    const [rightSort, setRightSort] = useState("mintNumber");
-    const [rightSortDir, setRightSortDir] = useState("asc");
+    const [rightSort, setRightSort] = useState("acquiredAt");
+    const [rightSortDir, setRightSortDir] = useState("desc");
 
     const [isMobile, setIsMobile] = useState(false);
     const [leftCollapsed, setLeftCollapsed] = useState(false);
@@ -137,6 +137,9 @@ const TradingPage = ({ userId }) => {
                         const rarityA = rarities.findIndex((r) => r.name === a.rarity);
                         const rarityB = rarities.findIndex((r) => r.name === b.rarity);
                         result = rarityA - rarityB;
+                        break;
+                    case "acquiredAt":
+                        result = new Date(a.acquiredAt) - new Date(b.acquiredAt);
                         break;
                     default:
                         result = 0;
@@ -367,6 +370,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="mintNumber">Mint Number</option>
                                             <option value="name">Name</option>
                                             <option value="rarity">Rarity</option>
+                                            <option value="acquiredAt">Acquisition Date</option>
                                         </select>
                                         <select value={leftSortDir} onChange={(e) => setLeftSortDir(e.target.value)}>
                                             <option value="asc">Ascending</option>
@@ -427,6 +431,7 @@ const TradingPage = ({ userId }) => {
                                             <option value="mintNumber">Mint Number</option>
                                             <option value="name">Name</option>
                                             <option value="rarity">Rarity</option>
+                                            <option value="acquiredAt">Acquisition Date</option>
                                         </select>
                                         <select value={rightSortDir} onChange={(e) => setRightSortDir(e.target.value)}>
                                             <option value="asc">Ascending</option>


### PR DESCRIPTION
## Summary
- default collection sort settings to acquisition date, descending
- support sorting by acquisition date in TradingPage
- expose acquisition date option in trading filters

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6867d77e4e008330ac47027f14459135