### PR TITLE
Remove card generation attempt limit

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -136,10 +136,11 @@ const claimAchievementReward = async (req, res) => {
     }
     if (reward.card) {
       rewardCard = await generateCardWithProbability();
-      if (rewardCard) {
-        rewardCard.acquiredAt = new Date();
-        user.cards.push(rewardCard);
+      if (!rewardCard) {
+        return res.status(500).json({ message: 'Failed to generate card reward: no cards available' });
       }
+      rewardCard.acquiredAt = new Date();
+      user.cards.push(rewardCard);
     }
 
     ach.claimed = true;

--- a/backend/src/helpers/cardHelpers.js
+++ b/backend/src/helpers/cardHelpers.js
@@ -29,6 +29,25 @@ const pickRarity = () => {
 
 // Generate a card with probabilities and ensure uniqueness across all user collections
 const generateCardWithProbability = async () => {
+    const currentTime = new Date();
+    const anyAvailable = await Card.exists({
+        'rarities.remainingCopies': { $gt: 0 },
+        'rarities.availableMintNumbers.0': { $exists: true },
+        $or: [
+            { availableFrom: null },
+            { availableFrom: { $lte: currentTime } }
+        ],
+        $or: [
+            { availableTo: null },
+            { availableTo: { $gte: currentTime } }
+        ]
+    });
+
+    if (!anyAvailable) {
+        console.error('[generateCardWithProbability] No cards available');
+        return null;
+    }
+
     while (true) {
         try {
             const selectedRarity = pickRarity();


### PR DESCRIPTION
## Summary
- remove maximum attempt limit from `generateCardWithProbability`
- check for any available cards before attempting generation
- return a clear error message when achievement rewards cannot generate a card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686860838a9483309cba2b0825f531aa