### PR TITLE
Add new achievements and profile updates

### DIFF
--- a/backend/src/controllers/achievementController.js
+++ b/backend/src/controllers/achievementController.js
@@ -39,6 +39,10 @@ const getAchievements = async (req, res) => {
     if (ALL_RARITIES.every(r => rarities.has(r))) fullSets += 1;
   }
 
+  const featuredCount = (user.featuredCards || []).length;
+  const modifierCards = (user.cards || []).filter(c => c.modifier).length;
+  const raritiesOwned = new Set((user.cards || []).map(c => c.rarity)).size;
+
   const hasModifierCard = (user.cards || []).some(c => c.modifier);
   const hasLegendaryCard = (user.cards || []).some(c =>
     ['Legendary', 'Mythic', 'Unique', 'Divine'].includes(c.rarity)
@@ -53,6 +57,9 @@ const getAchievements = async (req, res) => {
       else if (a.field === 'hasModifierCard') current = hasModifierCard ? 1 : 0;
       else if (a.field === 'hasLegendaryCard') current = hasLegendaryCard ? 1 : 0;
       else if (a.field === 'favoriteCard') current = user.favoriteCard ? 1 : 0;
+      else if (a.field === 'featuredCardsCount') current = featuredCount;
+      else if (a.field === 'modifierCards') current = modifierCards;
+      else if (a.field === 'raritiesOwned') current = raritiesOwned;
       else current = user[a.field] || 0;
       const achieved = current >= a.threshold;
       const userAch = user.achievements?.find(ua => ua.name === a.name);

--- a/backend/src/helpers/achievementHelper.js
+++ b/backend/src/helpers/achievementHelper.js
@@ -18,6 +18,10 @@ const checkAndGrantAchievements = async (user) => {
     if (ALL_RARITIES.every(r => rarities.has(r))) fullSets += 1;
   }
 
+  const featuredCount = (user.featuredCards || []).length;
+  const modifierCards = (user.cards || []).filter(c => c.modifier).length;
+  const raritiesOwned = new Set((user.cards || []).map(c => c.rarity)).size;
+
   const hasModifierCard = (user.cards || []).some(c => c.modifier);
   const hasLegendaryCard = (user.cards || []).some(c =>
     ['Legendary', 'Mythic', 'Unique', 'Divine'].includes(c.rarity)
@@ -40,6 +44,9 @@ const checkAndGrantAchievements = async (user) => {
     else if (achievement.field === 'hasModifierCard') progress = hasModifierCard ? 1 : 0;
     else if (achievement.field === 'hasLegendaryCard') progress = hasLegendaryCard ? 1 : 0;
     else if (achievement.field === 'favoriteCard') progress = user.favoriteCard ? 1 : 0;
+    else if (achievement.field === 'featuredCardsCount') progress = featuredCount;
+    else if (achievement.field === 'modifierCards') progress = modifierCards;
+    else if (achievement.field === 'raritiesOwned') progress = raritiesOwned;
     else progress = user[achievement.field] || 0;
     const alreadyHas = user.achievements.some(a => a.name === achievement.name);
 

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -56,6 +56,10 @@ const userSchema = new mongoose.Schema({
     isAdmin: { type: Boolean, default: false },
     lastActive: { type: Date }, // Last active in chat
     loginCount: { type: Number, default: 0 },
+    loginStreak: { type: Number, default: 0 },
+    lastLogin: { type: Date },
+
+    completedPurchases: { type: Number, default: 0 },
 
     // Gamification fields
     xp: { type: Number, default: 0 },

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -31,6 +31,8 @@ router.get(
                 packs: 1,
                 firstLogin: false,
                 loginCount: 1,
+                loginStreak: 1,
+                lastLogin: new Date(),
                 twitchProfilePic: user.profile_image_url // NEW: Save Twitch profile image URL
             };
             if (user.email) {
@@ -54,6 +56,13 @@ router.get(
                 console.log(`User ${dbUser.username} has already logged in before. No pack awarded.`);
             }
             dbUser.loginCount = (dbUser.loginCount || 0) + 1;
+            const now = new Date();
+            if (dbUser.lastLogin && (now - dbUser.lastLogin) <= 24 * 60 * 60 * 1000) {
+                dbUser.loginStreak = (dbUser.loginStreak || 0) + 1;
+            } else {
+                dbUser.loginStreak = 1;
+            }
+            dbUser.lastLogin = now;
             await dbUser.save();
         }
 

--- a/backend/src/services/marketService.js
+++ b/backend/src/services/marketService.js
@@ -236,6 +236,7 @@ async function finalizeOfferAcceptance({ seller, buyer, listing, offer }) {
   console.log('[Accept Offer Service] Notifications created.');
 
   seller.completedListings = (seller.completedListings || 0) + 1;
+  buyer.completedPurchases = (buyer.completedPurchases || 0) + 1;
 
   console.log('[Accept Offer Service] Awarding XP.');
   seller.xp = (seller.xp || 0) + 15;

--- a/config/achievements.js
+++ b/config/achievements.js
@@ -36,4 +36,21 @@ module.exports = [
   { key: 'LOGIN_I', name: 'Regular I', description: 'Login 10 times', field: 'loginCount', threshold: 10, reward: { card: true } },
   { key: 'LOGIN_II', name: 'Regular II', description: 'Login 50 times', field: 'loginCount', threshold: 50, reward: { card: true } },
   { key: 'LOGIN_III', name: 'Regular III', description: 'Login 100 times', field: 'loginCount', threshold: 100, reward: { packs: 1 } },
+  { key: 'FIRST_LOGIN', name: 'First Login', description: 'Login for the first time', field: 'loginCount', threshold: 1, reward: { card: true } },
+  { key: 'DAILY_STREAK', name: 'Daily Streak', description: 'Log in 7 days in a row', field: 'loginStreak', threshold: 7, reward: { packs: 1 } },
+  // Profile customization
+  { key: 'FEATURED_FAN', name: 'Featured Fan', description: 'Feature any card on your profile', field: 'featuredCardsCount', threshold: 1, reward: { card: true } },
+  { key: 'SHOWCASE_PRO', name: 'Showcase Pro', description: 'Feature four cards at once', field: 'featuredCardsCount', threshold: 4, reward: { packs: 1 } },
+  // Market purchases
+  { key: 'FIRST_PURCHASE', name: 'First Purchase', description: 'Buy your first card from the market', field: 'completedPurchases', threshold: 1, reward: { card: true } },
+  { key: 'BUYER_I', name: 'Buyer I', description: 'Buy 10 cards from listings', field: 'completedPurchases', threshold: 10, reward: { card: true } },
+  { key: 'BUYER_II', name: 'Buyer II', description: 'Buy 50 cards from listings', field: 'completedPurchases', threshold: 50, reward: { card: true } },
+  { key: 'BUYER_III', name: 'Buyer III', description: 'Buy 100 cards from listings', field: 'completedPurchases', threshold: 100, reward: { packs: 1 } },
+  // Additional milestones
+  { key: 'MASTER_TRADER', name: 'Master Trader', description: 'Complete 200 trades', field: 'completedTrades', threshold: 200, reward: { packs: 1 } },
+  { key: 'PACK_ADDICT', name: 'Pack Addict', description: 'Open 500 packs', field: 'openedPacks', threshold: 500, reward: { packs: 2 } },
+  { key: 'MODIFIER_HUNTER', name: 'Modifier Hunter', description: 'Own 10 cards with modifiers', field: 'modifierCards', threshold: 10, reward: { card: true } },
+  { key: 'RARITY_HUNTER', name: 'Rarity Hunter', description: 'Collect at least one card of every rarity', field: 'raritiesOwned', threshold: 10, reward: { packs: 1 } },
+  { key: 'SET_MASTER', name: 'Set Master', description: 'Own 10 full card sets', field: 'fullSets', threshold: 10, reward: { packs: 2 } },
+  { key: 'LEGEND_HOARDER', name: 'Legend Hoarder', description: 'Own 250 unique cards', field: 'uniqueCards', threshold: 250, reward: { packs: 2 } },
 ];

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -211,12 +211,14 @@ const ProfilePage = () => {
                 <h3>Achievements</h3>
                 <div className="achievements-container">
                     {achievements.length === 0 && <p>No achievements yet.</p>}
-                    {achievements.map((ach, idx) => (
+                {achievements.map((ach, idx) => (
                         <div key={idx} className="achievement-badge" title={ach.description} style={{ opacity: ach.achieved ? 1 : 0.4 }}>
                             <span>{ach.name}</span>
                         </div>
                     ))}
                 </div>
+
+            </div>
 
             <div className="favorite-card-container">
                 <h2>Favorite Card Wanted</h2>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -10,6 +10,7 @@ import {
     updateFavoriteCard,
     searchCardsByName,
     fetchUserMarketListings,
+    fetchAchievements,
 } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner';
 import '../styles/ProfilePage.css';
@@ -63,7 +64,6 @@ const ProfilePage = () => {
                 setOpenedPacks(profile.openedPacks || 0);
                 setXp(profile.xp || 0);
                 setLevel(profile.level || 1);
-                setAchievements(profile.achievements || []);
 
                 const ownProfile = me && profile && me.username === profile.username;
                 setIsOwnProfile(ownProfile);
@@ -99,6 +99,18 @@ const ProfilePage = () => {
         };
         fetchProfileData();
     }, [routeUsername]);
+
+    useEffect(() => {
+        const loadAchievements = async () => {
+            try {
+                const data = await fetchAchievements();
+                setAchievements(data.achievements || []);
+            } catch (e) {
+                console.error('Error fetching achievements:', e);
+            }
+        };
+        loadAchievements();
+    }, []);
 
     useEffect(() => {
         const fetchListings = async () => {
@@ -199,34 +211,12 @@ const ProfilePage = () => {
                 <h3>Achievements</h3>
                 <div className="achievements-container">
                     {achievements.length === 0 && <p>No achievements yet.</p>}
-
-                    {[
-                        { name: 'Level 1', description: 'Reached Level 1' },
-                        { name: 'Level 5', description: 'Reached Level 5' },
-                        { name: 'Level 10', description: 'Reached Level 10' },
-                        { name: 'Level 20', description: 'Reached Level 20' },
-                        { name: 'Level 50', description: 'Reached Level 50' },
-                        { name: 'Trader I', description: 'Completed 10 trades' },
-                        { name: 'Trader II', description: 'Completed 50 trades' },
-                        { name: 'Seller I', description: 'Sold 10 cards on the market' },
-                        { name: 'Seller II', description: 'Sold 50 cards on the market' },
-                        { name: 'Opener I', description: 'Opened 10 packs' },
-                        { name: 'Opener II', description: 'Opened 50 packs' },
-                    ].map((ach, idx) => {
-                        const unlocked = achievements.some(a => a.name === ach.name);
-                        return (
-                            <div
-                                key={idx}
-                                className="achievement-badge"
-                                title={ach.description}
-                                style={{ opacity: unlocked ? 1 : 0.4 }}
-                            >
-                                <span>{ach.name}</span>
-                            </div>
-                        );
-                    })}
+                    {achievements.map((ach, idx) => (
+                        <div key={idx} className="achievement-badge" title={ach.description} style={{ opacity: ach.achieved ? 1 : 0.4 }}>
+                            <span>{ach.name}</span>
+                        </div>
+                    ))}
                 </div>
-            </div>
 
             <div className="favorite-card-container">
                 <h2>Favorite Card Wanted</h2>


### PR DESCRIPTION
## Summary
- extend achievements config with new ideas
- track purchases and login streaks in the user model
- update login route to maintain streak data
- bump market service to increment buyer purchases
- compute new achievement fields
- show achievements dynamically on profile page

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687281b9f224833088e01eb7f7d41d9f