### PR TITLE
Add user preferred pack selection

### DIFF
--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -51,6 +51,8 @@ const userSchema = new mongoose.Schema({
         name: String,
         rarity: String,
     },
+    // User's preferred pack template for admin openings
+    preferredPack: { type: mongoose.Schema.Types.ObjectId, ref: 'Pack', default: null },
     notifications: [notificationSchema], // NEW: Notifications for the user
     firstLogin: { type: Boolean, default: false },
     isAdmin: { type: Boolean, default: false },

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -97,7 +97,9 @@ router.get('/users', protect, adminOnly, async (req, res) => {
     const start = process.hrtime();
     try {
         const dbStart = process.hrtime();
-        const users = await User.find({}, 'username packs').lean();
+        const users = await User.find({}, 'username packs preferredPack')
+                               .populate('preferredPack', 'name')
+                               .lean();
         const dbEnd = process.hrtime(dbStart);
         console.log(`[PERF] [admin/users] DB query took ${dbEnd[0] * 1000 + dbEnd[1] / 1e6} ms`);
         const total = process.hrtime(start);
@@ -139,7 +141,8 @@ router.get('/users-activity', protect, adminOnly, async (req, res) => {
             query = { lastActive: { $gte: cutoff } };
         }
 
-        const users = await User.find(query, 'username packs lastActive')
+        const users = await User.find(query, 'username packs lastActive preferredPack')
+                                .populate('preferredPack', 'name')
                                 .sort({ lastActive: -1 }); // Sort by last active, most recent first
 
         res.json(users);

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -9,6 +9,8 @@ const {
     updateFeaturedAchievements,
     getFavoriteCard,
     updateFavoriteCard,
+    getPreferredPack,
+    updatePreferredPack,
     searchUsers,
 } = require('../controllers/userController');
 const { protect } = require('../middleware/authMiddleware');
@@ -53,6 +55,10 @@ router.put('/featured-achievements', protect, updateFeaturedAchievements);
 // Favorite card routes
 router.get('/favorite-card', protect, getFavoriteCard);
 router.put('/favorite-card', protect, updateFavoriteCard);
+
+// Preferred pack routes
+router.get('/preferred-pack', protect, getPreferredPack);
+router.put('/preferred-pack', protect, updatePreferredPack);
 
 // Route to fetch all cards in the user's collection
 router.get('/:userId/collection', protect, async (req, res) => {

--- a/frontend/src/pages/AdminDashboardPage.js
+++ b/frontend/src/pages/AdminDashboardPage.js
@@ -133,6 +133,14 @@ const AdminDashboardPage = ({ user }) => {
             return sortDirection === 'asc' ? dateA - dateB : dateB - dateA;
         }
 
+        if (sortColumn === 'preferredPack') {
+            const nameA = aValue?.name || '';
+            const nameB = bValue?.name || '';
+            return sortDirection === 'asc'
+                ? nameA.localeCompare(nameB)
+                : nameB.localeCompare(nameA);
+        }
+
         if (aValue < bValue) {
             return sortDirection === 'asc' ? -1 : 1;
         }
@@ -303,6 +311,7 @@ const AdminDashboardPage = ({ user }) => {
                             <tr>
                                 <th onClick={() => handleSort('username')}>Username</th>
                                 <th onClick={() => handleSort('packs')}>Unopened Packs</th>
+                                <th onClick={() => handleSort('preferredPack')}>Preferred Pack</th>
                                 <th onClick={() => handleSort('lastActive')}>Last Active</th>
                             </tr>
                         </thead>
@@ -315,6 +324,7 @@ const AdminDashboardPage = ({ user }) => {
                                 >
                                     <td>{u.username}</td>
                                     <td>{u.packs}</td>
+                                    <td>{u.preferredPack ? (u.preferredPack.name || u.preferredPack.type || 'Unnamed') : '-'}</td>
                                     <td>{u.lastActive ? moment(u.lastActive).fromNow() : 'Never'}</td>
                                 </tr>
                             ))}

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -10,6 +10,9 @@ import {
     updateFavoriteCard,
     searchCardsByName,
     fetchUserMarketListings,
+    fetchAllPacks,
+    fetchPreferredPack,
+    updatePreferredPack,
 } from '../utils/api';
 import LoadingSpinner from '../components/LoadingSpinner';
 import '../styles/ProfilePage.css';
@@ -22,6 +25,8 @@ const ProfilePage = () => {
     const [cardQuery, setCardQuery] = useState('');
     const [cardResults, setCardResults] = useState([]);
     const [selectedRarity, setSelectedRarity] = useState('');
+    const [preferredPackId, setPreferredPackId] = useState('');
+    const [packOptions, setPackOptions] = useState([]);
     const [editingFavorite, setEditingFavorite] = useState(false);
     const [isOwnProfile, setIsOwnProfile] = useState(false);
     const [collectionCount, setCollectionCount] = useState(0);
@@ -42,6 +47,9 @@ const ProfilePage = () => {
     useEffect(() => {
         const fetchProfileData = async () => {
             try {
+                const packs = await fetchAllPacks();
+                setPackOptions(packs);
+
                 // Determine if the logged-in user is viewing their own profile
                 let me = null;
                 try {
@@ -63,6 +71,7 @@ const ProfilePage = () => {
                 setOpenedPacks(profile.openedPacks || 0);
                 setXp(profile.xp || 0);
                 setLevel(profile.level || 1);
+                setPreferredPackId(profile.preferredPack?._id || '');
 
                 const ownProfile = me && profile && me.username === profile.username;
                 setIsOwnProfile(ownProfile);
@@ -72,6 +81,8 @@ const ProfilePage = () => {
                     try {
                         const fav = await fetchFavoriteCard();
                         setFavoriteCard(fav);
+                        const pref = await fetchPreferredPack();
+                        setPreferredPackId(pref?._id || '');
                     } catch (e) {
                         console.error('Error fetching favorite card:', e);
                     }
@@ -283,6 +294,31 @@ const ProfilePage = () => {
                     View Full Collection
                 </button>
             </div>
+
+            {isOwnProfile && (
+                <div className="preferred-pack-container">
+                    <h2>Preferred Pack</h2>
+                    <select
+                        value={preferredPackId}
+                        onChange={async (e) => {
+                            const id = e.target.value;
+                            setPreferredPackId(id);
+                            try {
+                                await updatePreferredPack(id);
+                            } catch (err) {
+                                console.error('Error updating preferred pack:', err);
+                            }
+                        }}
+                    >
+                        <option value="">Select a pack</option>
+                        {packOptions.map((p) => (
+                            <option key={p._id} value={p._id}>
+                                {p.name || p.type || 'Unnamed'}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            )}
 
             <div className="featured-cards-container">
                 <h2>Featured Cards</h2>

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -266,6 +266,26 @@ body {
     grid-column: span 1;
 }
 
+.preferred-pack-container {
+    margin-top: 2rem;
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    text-align: center;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+    grid-column: span 1;
+}
+
+.preferred-pack-container select {
+    padding: 0.5rem 1rem;
+    margin-top: 0.5rem;
+    background: var(--surface-darker);
+    color: var(--text-primary);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--border-radius);
+}
+
 .favorite-card-display {
     --card-scale: var(--screen-card-scale);
     display: flex;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -209,6 +209,42 @@ export const updateFavoriteCard = async (name, rarity) => {
     }
 };
 
+// Fetch preferred pack for the logged-in user
+export const fetchPreferredPack = async () => {
+    try {
+        const response = await fetchWithAuth('/api/users/preferred-pack', { method: 'GET' });
+        return response.preferredPack;
+    } catch (error) {
+        console.error('[API] Error fetching preferred pack:', error.message);
+        throw error;
+    }
+};
+
+// Update preferred pack for the logged-in user
+export const updatePreferredPack = async (packId) => {
+    try {
+        const response = await fetchWithAuth('/api/users/preferred-pack', {
+            method: 'PUT',
+            body: JSON.stringify({ packId }),
+        });
+        return response.preferredPack;
+    } catch (error) {
+        console.error('[API] Error updating preferred pack:', error.message);
+        throw error;
+    }
+};
+
+// Fetch list of all packs (public)
+export const fetchAllPacks = async () => {
+    try {
+        const res = await fetchWithAuth('/api/admin/packs', { method: 'GET' });
+        return res.packs || [];
+    } catch (err) {
+        console.error('[API] Error fetching packs:', err.message);
+        throw err;
+    }
+};
+
 // Create a new trade
 export const createTrade = async (tradeData) => {
     try {


### PR DESCRIPTION
## Summary
- let users store a preferred pack for pack openings
- expose GET/PUT `/api/users/preferred-pack`
- show preferred pack column on the admin dashboard
- allow users to select their preferred pack on their profile page
- extend API helpers for preferred pack logic

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c568ed48833085a9b71512c35144