### PR TITLE
Move preferred pack dropdown under trade buttons

### DIFF
--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -293,32 +293,32 @@ const ProfilePage = () => {
                 <button className="profile-action-button" onClick={handleViewCollection}>
                     View Full Collection
                 </button>
-            </div>
 
-            {isOwnProfile && (
-                <div className="preferred-pack-container">
-                    <h2>Preferred Pack</h2>
-                    <select
-                        value={preferredPackId}
-                        onChange={async (e) => {
-                            const id = e.target.value;
-                            setPreferredPackId(id);
-                            try {
-                                await updatePreferredPack(id);
-                            } catch (err) {
-                                console.error('Error updating preferred pack:', err);
-                            }
-                        }}
-                    >
-                        <option value="">Select a pack</option>
-                        {packOptions.map((p) => (
-                            <option key={p._id} value={p._id}>
-                                {p.name || p.type || 'Unnamed'}
-                            </option>
-                        ))}
-                    </select>
-                </div>
-            )}
+                {isOwnProfile && (
+                    <div className="preferred-pack-container">
+                        <h2>Preferred Pack</h2>
+                        <select
+                            value={preferredPackId}
+                            onChange={async (e) => {
+                                const id = e.target.value;
+                                setPreferredPackId(id);
+                                try {
+                                    await updatePreferredPack(id);
+                                } catch (err) {
+                                    console.error('Error updating preferred pack:', err);
+                                }
+                            }}
+                        >
+                            <option value="">Select a pack</option>
+                            {packOptions.map((p) => (
+                                <option key={p._id} value={p._id}>
+                                    {p.name || p.type || 'Unnamed'}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+            </div>
 
             <div className="featured-cards-container">
                 <h2>Featured Cards</h2>

--- a/frontend/src/styles/ProfilePage.css
+++ b/frontend/src/styles/ProfilePage.css
@@ -267,7 +267,7 @@ body {
 }
 
 .preferred-pack-container {
-    margin-top: 2rem;
+    margin-top: 1rem;
     background: var(--surface-dark);
     border: 1px solid var(--border-dark);
     padding: 1rem;


### PR DESCRIPTION
## Summary
- reposition preferred pack dropdown inside the trade actions container
- tweak spacing of preferred pack container

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872c88e8ee48330bdad219b015f9b0b