### PR TITLE
Implement card grading (admin-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Run these commands from the `backend` directory.
 
 Refer to [`backend/README_trading_market.md`](backend/README_trading_market.md) for additional backend documentation.
 
+## Card Grading (Admin Only)
+
+Admins can grade any card from the `/admin/grading` page. Selecting a user and card will assign a random grade from 1–10 and mark the card as slabbed. Graded cards display a plastic "slab" overlay with the project logo and grade value.
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -35,6 +35,7 @@ const notificationRoutes = require('./src/routes/notificationRoutes');
 const testNotificationRoutes = require('./src/routes/testNotificationRoutes');
 const adminRoutes = require('./src/routes/adminRoutes');
 const achievementRoutes = require('./src/routes/achievementRoutes');
+const gradingRoutes = require('./src/routes/gradingRoutes');
 
 const app = express();
 app.set('trust proxy', 1);
@@ -97,6 +98,7 @@ app.use('/api/market', marketRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/test-notification', testNotificationRoutes); // Ensure this is correctly set up
 app.use('/api/admin', adminRoutes);
+app.use('/api/grading', gradingRoutes);
 app.use('/api/modifiers', require('./src/routes/modifierRoutes'));
 app.use('/api/achievements', achievementRoutes);
 

--- a/backend/src/controllers/gradingController.js
+++ b/backend/src/controllers/gradingController.js
@@ -1,0 +1,36 @@
+const User = require('../models/userModel');
+
+function weightedRandomGrade() {
+    const weights = {10:1,9:3,8:7,7:10,6:12,5:14,4:12,3:10,2:7,1:4};
+    const total = Object.values(weights).reduce((a,b)=>a+b,0);
+    let rand = Math.random()*total;
+    for (const grade of Object.keys(weights).sort((a,b)=>b-a)) {
+        rand -= weights[grade];
+        if (rand < 0) return Number(grade);
+    }
+    return 5;
+}
+
+const gradeCard = async (req, res) => {
+    const { userId, cardId } = req.body;
+    if (!userId || !cardId) {
+        return res.status(400).json({ message: 'userId and cardId are required' });
+    }
+    try {
+        const user = await User.findById(userId);
+        if (!user) return res.status(404).json({ message: 'User not found' });
+        const card = user.cards.id(cardId);
+        if (!card) return res.status(404).json({ message: 'Card not found' });
+        const grade = weightedRandomGrade();
+        card.grade = grade;
+        card.slabbed = true;
+        card.gradedAt = new Date();
+        await user.save();
+        res.json({ card });
+    } catch (err) {
+        console.error('Error grading card:', err);
+        res.status(500).json({ message: 'Failed to grade card' });
+    }
+};
+
+module.exports = { gradeCard };

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -14,6 +14,9 @@ const cardSchema = new mongoose.Schema({
         default: 'available',
         index: true,
     }, // Card status
+    grade: { type: Number, min: 1, max: 10 },
+    slabbed: { type: Boolean, default: false },
+    gradedAt: Date,
 });
 
 // Index nested card id for faster $elemMatch queries

--- a/backend/src/routes/gradingRoutes.js
+++ b/backend/src/routes/gradingRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { protect, adminOnly } = require('../middleware/authMiddleware');
+const { gradeCard } = require('../controllers/gradingController');
+
+const router = express.Router();
+
+router.post('/grade-card', protect, adminOnly, gradeCard);
+
+module.exports = router;

--- a/backend/tests/grading.test.js
+++ b/backend/tests/grading.test.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+const User = require('../src/models/userModel');
+const { gradeCard } = require('../src/controllers/gradingController');
+
+jest.mock('../src/models/userModel');
+
+describe('grading controller', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns error when missing params', async () => {
+    const req = { body: {}, user: { isAdmin: true } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await gradeCard(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,7 @@ const MarketPage = lazy(() => import('./pages/MarketPage'));
 const CreateListingPage = lazy(() => import('./pages/CreateListingPage'));
 const MarketListingDetails = lazy(() => import('./pages/MarketListingDetails'));
 const AdminActions = lazy(() => import('./pages/AdminActions'));
+const AdminGradingPage = lazy(() => import('./pages/AdminGradingPage'));
 const CardEditor = lazy(() => import('./components/CardEditor'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 const AchievementsPage = lazy(() => import('./pages/AchievementsPage'));
@@ -139,6 +140,10 @@ const App = () => {
                     <Route
                         path="/admin/actions"
                         element={user?.isAdmin ? <AdminActions user={user} /> : <Navigate to="/login" />}
+                    />
+                    <Route
+                        path="/admin/grading"
+                        element={user?.isAdmin ? <AdminGradingPage /> : <Navigate to="/login" />}
                     />
                     <Route path="/catalogue" element={<CataloguePage />} />
                     <Route path="/market" element={<MarketPage />} />

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -17,6 +17,8 @@ const BaseCard = ({
   inspectOnClick = true,
   interactive = true,
   modifier,
+  grade,
+  slabbed,
 }) => {
   const cardRef = useRef(null);
   const nameRef = useRef(null);
@@ -370,6 +372,12 @@ const BaseCard = ({
       )}
       {modifierData?.name === 'Prismatic' && (
         <div className="prismatic-overlay" />
+      )}
+      {slabbed && (
+        <div className="slab-overlay">
+          <img src="/images/NedsDecksLogo.png" alt="logo" className="slab-logo" />
+          <div className="slab-grade">{grade}</div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { fetchWithAuth, gradeCard } from '../utils/api';
+import BaseCard from '../components/BaseCard';
+
+const AdminGradingPage = () => {
+    const [users, setUsers] = useState([]);
+    const [selectedUser, setSelectedUser] = useState('');
+    const [cards, setCards] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const loadUsers = async () => {
+            try {
+                const data = await fetchWithAuth('/api/admin/users');
+                setUsers(data);
+            } catch (err) {
+                console.error('Error fetching users', err);
+            }
+        };
+        loadUsers();
+    }, []);
+
+    const handleSelectUser = async (e) => {
+        const id = e.target.value;
+        setSelectedUser(id);
+        if (!id) return;
+        setLoading(true);
+        try {
+            const data = await fetchWithAuth(`/api/users/${id}/collection`);
+            setCards(data.cards || []);
+        } catch (err) {
+            console.error('Error fetching collection', err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleGrade = async (cardId) => {
+        try {
+            await gradeCard(selectedUser, cardId);
+            const data = await fetchWithAuth(`/api/users/${selectedUser}/collection`);
+            setCards(data.cards || []);
+        } catch (err) {
+            console.error('Error grading card', err);
+        }
+    };
+
+    return (
+        <div className="admin-grading-page">
+            <h2>Admin Card Grading</h2>
+            <label>
+                Select User:
+                <select value={selectedUser} onChange={handleSelectUser}>
+                    <option value="">-- choose user --</option>
+                    {users.map(u => (
+                        <option key={u._id} value={u._id}>{u.username}</option>
+                    ))}
+                </select>
+            </label>
+            {loading && <p>Loading cards...</p>}
+            <div className="grading-card-list">
+                {cards.map(card => (
+                    <div key={card._id} className="grading-card-item">
+                        <BaseCard {...card} grade={card.grade} slabbed={card.slabbed} />
+                        {!card.slabbed && (
+                            <button onClick={() => handleGrade(card._id)}>Grade</button>
+                        )}
+                        {card.slabbed && <span>Grade: {card.grade}</span>}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default AdminGradingPage;

--- a/frontend/src/pages/__tests__/AdminGradingPage.test.js
+++ b/frontend/src/pages/__tests__/AdminGradingPage.test.js
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import AdminGradingPage from '../AdminGradingPage';
+
+test('renders grading page heading', () => {
+  const { getByText } = render(<AdminGradingPage />);
+  const heading = getByText(/Admin Card Grading/i);
+  expect(heading).not.toBeNull();
+});

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -787,6 +787,38 @@
     animation: glitchBottom 1.2s infinite linear alternate-reverse;
 }
 
+.slab-overlay {
+    position: absolute;
+    inset: 0;
+    border-radius: 12px;
+    border: 6px solid rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.15);
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.6);
+    pointer-events: none;
+    z-index: 6;
+}
+
+.slab-logo {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    width: 40px;
+    pointer-events: none;
+}
+
+.slab-grade {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: black;
+    background: rgba(255,255,255,0.8);
+    padding: 2px 6px;
+    border-radius: 4px;
+    pointer-events: none;
+}
+
 @keyframes glitchTop {
     0% { transform: translate(0); }
     20% { transform: translate(-2px, -2px); }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -431,3 +431,16 @@ export const claimAchievement = async (name) => {
         throw error;
     }
 };
+
+// Grade a specific card for a user (admin only)
+export const gradeCard = async (userId, cardId) => {
+    try {
+        return await fetchWithAuth('/api/grading/grade-card', {
+            method: 'POST',
+            body: JSON.stringify({ userId, cardId }),
+        });
+    } catch (error) {
+        console.error('[API] Error grading card:', error.message);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- add `grade`, `slabbed` and `gradedAt` fields on user cards
- create controller and routes for grading endpoint
- expose `/api/grading/grade-card` in the server
- implement admin-only grading page in frontend
- render slab overlay and grade label in `BaseCard`
- add CSS for slab visuals
- add simple unit tests
- document grading feature

## Testing
- `CI=true npm test --silent` in `frontend`
- `npm test --silent` in `backend` *(expected failure: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873d588b068833089ee8015def85232