### PR TITLE
Improve admin grading

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -167,6 +167,15 @@ const Navbar = ({ isAdmin }) => {
                                 Admin Actions
                             </NavLink>
                         </li>
+                        <li>
+                            <NavLink
+                                to="/admin/grading"
+                                className="nav-link"
+                                onClick={() => setMenuOpen(false)}
+                            >
+                                Admin Grading
+                            </NavLink>
+                        </li>
                     </>
                 )}
                 <li>

--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth, gradeCard } from '../utils/api';
 import BaseCard from '../components/BaseCard';
+import '../styles/AdminGradingPage.css';
 
 const AdminGradingPage = () => {
     const [users, setUsers] = useState([]);

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -1,0 +1,47 @@
+/* Admin Grading Page */
+.admin-grading-page {
+    padding: 40px 20px;
+    max-width: 1800px;
+    margin: 0 auto;
+    background-color: var(--background-dark);
+    color: var(--text-primary);
+    min-height: 100vh;
+}
+
+.admin-grading-page h2 {
+    text-align: center;
+    margin-top: 80px;
+    margin-bottom: 40px;
+    font-size: 2.8rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+}
+
+.grading-card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 2rem;
+    justify-items: center;
+}
+
+.grading-card-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.grading-card-item button {
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: var(--brand-primary);
+    color: var(--background-dark);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.grading-card-item button:hover {
+    background: var(--brand-secondary);
+    transform: scale(1.05);
+}

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -789,33 +789,48 @@
 
 .slab-overlay {
     position: absolute;
-    inset: 0;
-    border-radius: 12px;
-    border: 6px solid rgba(255, 255, 255, 0.6);
-    background: rgba(255, 255, 255, 0.15);
-    box-shadow: inset 0 0 10px rgba(0,0,0,0.6);
+    inset: -4px;
+    border-radius: 14px;
+    border: 8px solid rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow:
+        0 2px 8px rgba(0,0,0,0.6),
+        inset 0 0 12px rgba(255,255,255,0.4),
+        inset 0 0 3px rgba(0,0,0,0.6);
     pointer-events: none;
     z-index: 6;
 }
 
+.slab-overlay::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 48px;
+    background: linear-gradient(to bottom, rgba(255,255,255,0.95), rgba(255,255,255,0.6));
+    border-bottom: 2px solid rgba(0,0,0,0.2);
+    border-radius: 8px 8px 0 0;
+}
+
 .slab-logo {
     position: absolute;
-    top: 6px;
-    left: 6px;
-    width: 40px;
+    top: 8px;
+    left: 8px;
+    width: 36px;
     pointer-events: none;
 }
 
 .slab-grade {
     position: absolute;
-    top: 6px;
-    right: 6px;
-    font-size: 1.2rem;
+    top: 12px;
+    right: 10px;
+    font-size: 1.4rem;
     font-weight: bold;
-    color: black;
-    background: rgba(255,255,255,0.8);
-    padding: 2px 6px;
-    border-radius: 4px;
+    color: #111;
+    background: none;
+    padding: 0;
+    text-shadow: 0 0 2px rgba(0,0,0,0.4);
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- link grading page from the admin navbar
- import a new stylesheet for the grading page
- style grading page for consistency with admin sections
- enhance the graded card slab overlay

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874d2bbbd64833094527936e9edc935