### PR TITLE
Improve admin grading

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -223,7 +223,7 @@ const BaseCard = ({
   return (
     <div
       ref={cardRef}
-      className={`card-container ${rarity.toLowerCase()}`}
+      className={`card-container ${rarity.toLowerCase()}${slabbed ? ' slabbed' : ''}`}
       onMouseMove={interactive ? handleMouseMove : undefined}
       onMouseLeave={interactive ? handleMouseLeave : undefined}
       draggable={draggable}
@@ -377,6 +377,7 @@ const BaseCard = ({
         <div className="slab-overlay">
           <img src="/images/NedsDecksLogo.png" alt="logo" className="slab-logo" />
           <div className="slab-grade">{grade}</div>
+          <div className="slab-name">{name}</div>
         </div>
       )}
     </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -167,6 +167,15 @@ const Navbar = ({ isAdmin }) => {
                                 Admin Actions
                             </NavLink>
                         </li>
+                        <li>
+                            <NavLink
+                                to="/admin/grading"
+                                className="nav-link"
+                                onClick={() => setMenuOpen(false)}
+                            >
+                                Admin Grading
+                            </NavLink>
+                        </li>
                     </>
                 )}
                 <li>

--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth, gradeCard } from '../utils/api';
 import BaseCard from '../components/BaseCard';
+import '../styles/AdminGradingPage.css';
 
 const AdminGradingPage = () => {
     const [users, setUsers] = useState([]);
@@ -61,7 +62,16 @@ const AdminGradingPage = () => {
             <div className="grading-card-list">
                 {cards.map(card => (
                     <div key={card._id} className="grading-card-item">
-                        <BaseCard {...card} grade={card.grade} slabbed={card.slabbed} />
+                        <BaseCard
+                            name={card.name}
+                            image={card.imageUrl}
+                            description={card.flavorText}
+                            rarity={card.rarity}
+                            mintNumber={card.mintNumber}
+                            modifier={card.modifier}
+                            grade={card.grade}
+                            slabbed={card.slabbed}
+                        />
                         {!card.slabbed && (
                             <button onClick={() => handleGrade(card._id)}>Grade</button>
                         )}

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -1,0 +1,47 @@
+/* Admin Grading Page */
+.admin-grading-page {
+    padding: 40px 20px;
+    max-width: 1800px;
+    margin: 0 auto;
+    background-color: var(--background-dark);
+    color: var(--text-primary);
+    min-height: 100vh;
+}
+
+.admin-grading-page h2 {
+    text-align: center;
+    margin-top: 80px;
+    margin-bottom: 40px;
+    font-size: 2.8rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+}
+
+.grading-card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    justify-items: center;
+}
+
+.grading-card-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.grading-card-item button {
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: var(--brand-primary);
+    color: var(--background-dark);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.grading-card-item button:hover {
+    background: var(--brand-secondary);
+    transform: scale(1.05);
+}

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -163,6 +163,11 @@
     margin-left: 10px;
 }
 
+/* Hide original name when slabbed */
+.card-container.slabbed .card-name {
+    visibility: hidden;
+}
+
 /**************************************
  * Glare for Lower Rarities (Basic → Uncommon)
  * Now matches the border color with alpha
@@ -789,34 +794,61 @@
 
 .slab-overlay {
     position: absolute;
-    inset: 0;
-    border-radius: 12px;
-    border: 6px solid rgba(255, 255, 255, 0.6);
-    background: rgba(255, 255, 255, 0.15);
-    box-shadow: inset 0 0 10px rgba(0,0,0,0.6);
+    inset: -6px;
+    border-radius: 18px;
+    border: 10px solid rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow:
+        0 4px 12px rgba(0,0,0,0.7),
+        inset 0 0 14px rgba(255,255,255,0.5),
+        inset 0 0 5px rgba(0,0,0,0.6);
     pointer-events: none;
     z-index: 6;
 }
 
+.slab-overlay::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    background: linear-gradient(to bottom, rgba(255,255,255,0.95), rgba(255,255,255,0.6));
+    border-bottom: 2px solid rgba(0,0,0,0.2);
+    border-radius: 10px 10px 0 0;
+}
+
 .slab-logo {
     position: absolute;
-    top: 6px;
-    left: 6px;
+    top: 10px;
+    left: 10px;
     width: 40px;
     pointer-events: none;
 }
 
 .slab-grade {
     position: absolute;
-    top: 6px;
-    right: 6px;
-    font-size: 1.2rem;
+    top: 12px;
+    right: 12px;
+    font-size: 1.5rem;
     font-weight: bold;
-    color: black;
-    background: rgba(255,255,255,0.8);
-    padding: 2px 6px;
-    border-radius: 4px;
+    color: #111;
+    background: none;
+    padding: 0;
+    text-shadow: 0 0 2px rgba(0,0,0,0.4);
     pointer-events: none;
+}
+
+.slab-name {
+    position: absolute;
+    top: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-weight: bold;
+    font-size: 0.9rem;
+    color: #111;
+    pointer-events: none;
+    white-space: nowrap;
 }
 
 @keyframes glitchTop {


### PR DESCRIPTION
## Summary
- link grading page from the admin navbar
- import a new stylesheet for the grading page
- style grading page for consistency with admin sections
- enhance the graded card slab overlay
- fix mapping of card properties so art and text display
- adjust grading page grid to prevent overlapping
- refine slab style and center label on graded cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874d2bbbd64833094527936e9edc935