### PR TITLE
Improve graded card slab layout

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -375,9 +375,11 @@ const BaseCard = ({
       )}
       {slabbed && (
         <div className="slab-overlay">
-          <img src="/images/NedsDecksLogo.png" alt="logo" className="slab-logo" />
-          <div className="slab-grade">{grade}</div>
-          <div className="slab-name">{name}</div>
+          <div className="slab-header">
+            <img src="/images/NedsDecksLogo.png" alt="logo" className="slab-logo" />
+            <div className="slab-name">{name}</div>
+            <div className="slab-grade">{grade}</div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -168,6 +168,13 @@
     visibility: hidden;
 }
 
+/* Allow slab overlay to extend above the card */
+.card-container.slabbed {
+    overflow: visible;
+    height: calc(var(--card-height) + 72px);
+    padding-top: 72px;
+}
+
 /**************************************
  * Glare for Lower Rarities (Basic → Uncommon)
  * Now matches the border color with alpha
@@ -794,9 +801,12 @@
 
 .slab-overlay {
     position: absolute;
-    inset: -6px;
-    border-radius: 18px;
-    border: 10px solid rgba(255, 255, 255, 0.9);
+    top: -72px;
+    left: -12px;
+    right: -12px;
+    bottom: -12px;
+    border-radius: 25px;
+    border: 20px solid rgba(255, 255, 255, 0.9);
     background: rgba(255, 255, 255, 0.1);
     box-shadow:
         0 4px 12px rgba(0,0,0,0.7),
@@ -818,36 +828,40 @@
     border-radius: 10px 10px 0 0;
 }
 
-.slab-logo {
+.slab-header {
     position: absolute;
-    top: 10px;
-    left: 10px;
-    width: 40px;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 10px;
     pointer-events: none;
 }
 
+.slab-logo {
+    width: 40px;
+    flex: 0 0 auto;
+}
+
 .slab-grade {
-    position: absolute;
-    top: 12px;
-    right: 12px;
     font-size: 1.5rem;
     font-weight: bold;
     color: #111;
     background: none;
     padding: 0;
     text-shadow: 0 0 2px rgba(0,0,0,0.4);
-    pointer-events: none;
+    flex: 0 0 auto;
 }
 
 .slab-name {
-    position: absolute;
-    top: 32px;
-    left: 50%;
-    transform: translateX(-50%);
     font-weight: bold;
     font-size: 0.9rem;
     color: #111;
-    pointer-events: none;
+    flex: 1 1 auto;
+    text-align: center;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the slab overlay so it surrounds the card
- vertically align logo, name and grade in a new header container
- allow the slab overlay to extend above the card so the top isn't clipped

## Testing
- `CI=true npm test --silent`
- `npm test --silent` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6874e7b464848330a905a5ce375ac984