### PR TITLE
Improve card slab styling

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -163,22 +163,20 @@
     margin-left: 10px;
 }
 
-/* Hide original name when slabbed */
+/* Keep original card name visible when slabbed */
 .card-container.slabbed .card-name {
-    visibility: hidden;
+    visibility: visible;
 }
 
 /* Allow slab overlay to extend above the card */
 .card-container.slabbed {
     overflow: visible;
-    height: calc(var(--card-height) + 72px);
-    padding-top: 72px;
     background: none;
 }
 
 .card-container.slabbed .card-border {
-    margin: 12px;
-    height: calc(100% - 24px);
+    margin: 0;
+    height: 100%;
     background: #3a2525;
 }
 
@@ -808,19 +806,19 @@
 
 .slab-overlay {
     position: absolute;
-    top: -72px;
-    left: -24px;
-    right: -24px;
-    bottom: -24px;
-    border-radius: 12px;
-    border: 30px solid rgba(255, 255, 255, 0.9);
+    top: -60px;
+    left: -20px;
+    right: -20px;
+    bottom: -20px;
+    border-radius: 10px;
+    border: 12px solid rgba(255, 255, 255, 0.9);
     background: rgba(255, 255, 255, 0.1);
     box-shadow:
-        0 4px 12px rgba(0,0,0,0.7),
-        inset 0 0 14px rgba(255,255,255,0.5),
-        inset 0 0 5px rgba(0,0,0,0.6);
+        0 4px 8px rgba(0,0,0,0.6),
+        inset 0 0 12px rgba(255,255,255,0.5),
+        inset 0 0 4px rgba(0,0,0,0.6);
     pointer-events: none;
-    z-index: 6;
+    z-index: 8; /* above other rarity effects */
 }
 
 .slab-overlay::before {
@@ -829,10 +827,10 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 56px;
-    background: linear-gradient(to bottom, rgba(255,255,255,0.95), rgba(255,255,255,0.6));
-    border-bottom: 2px solid rgba(0,0,0,0.2);
-    border-radius: 8px 8px 0 0;
+    height: 48px;
+    background: rgba(255,255,255,0.9);
+    border-bottom: 2px solid rgba(255,255,255,0.9);
+    border-radius: 6px 6px 0 0;
 }
 
 .slab-header {
@@ -840,21 +838,21 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 56px;
+    height: 48px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 10px;
+    padding: 0 8px;
     pointer-events: none;
 }
 
 .slab-logo {
-    width: 40px;
+    width: 36px;
     flex: 0 0 auto;
 }
 
 .slab-grade {
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     font-weight: bold;
     color: #111;
     background: none;


### PR DESCRIPTION
## Summary
- fix slab layout so card stays full size
- reduce slab border thickness
- keep card name visible when slabbed
- unify slab header and border color
- ensure slab overlays sit above rarity effects

## Testing
- `npm test` *(fails: Missing script)*
- `npm test -- -w=1` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6875173e7e70833082fb8e018fddaec5