### PR TITLE
Adjust card glare size and hover effect

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -157,7 +157,7 @@ const BaseCard = ({
     ) {
       const gx = ((x/rect.width)*100).toFixed(2);
       const gy = ((y/rect.height)*100).toFixed(2);
-      glareRef.current.style.transform = 'translate(-50%,-50%) scale(1.2)';
+      glareRef.current.style.transform = 'translate(-50%,-50%) scale(1.1)';
       glareRef.current.style.opacity = '0.6';
       glareRef.current.style.background = `radial-gradient(circle at ${gx}% ${gy}%, var(--glare-color), rgba(255,255,255,0))`;
     }

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -204,8 +204,8 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 150%;
-    height: 150%;
+    width: 120%;
+    height: 120%;
     border-radius: 50%;
     pointer-events: none;
     z-index: 3;
@@ -220,7 +220,7 @@
 .card-container.standard:hover .card-glare,
 .card-container.uncommon:hover .card-glare {
     opacity: 0.6;
-    transform: translate(-50%, -50%) scale(1.2);
+    transform: translate(-50%, -50%) scale(1.1);
 }
 
 /**************************************


### PR DESCRIPTION
## Summary
- reduce glare size and hover scale for standard cards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875431827e48330bef2ff04895f5f1a