### PR TITLE
Fix slabbed card clipping

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -39,6 +39,8 @@ const CollectionPage = ({
     const [loading, setLoading] = useState(true);
     const [totalPacks, setTotalPacks] = useState(0); // new state for packs
 
+    const hasSlabbed = filteredCards.some(card => card.slabbed);
+
     // Card Container Scale Slider
     const defaultCardScale = 1;
     const [cardScale, setCardScale] = useState(() => {
@@ -385,8 +387,8 @@ const handleCardClick = (card) => {
                 </div>
             </div>
 
-            {/* Cards Grid (unchanged) */}
-            <div className="cp-cards-grid" style={{ "--user-card-scale": cardScale }}>
+            {/* Cards Grid */}
+            <div className={`cp-cards-grid ${hasSlabbed ? 'slabbed' : ''}`} style={{ "--user-card-scale": cardScale }}>
                 {filteredCards.length > 0 ? (
                     filteredCards.map((card) => {
                         const isFeatured = featuredCards.some((fc) => fc._id === card._id);
@@ -395,7 +397,7 @@ const handleCardClick = (card) => {
                             <div
                                 key={card._id}
                                 id={`cp-card-${card._id}`}
-                                className={`cp-card-item ${isSelected ? 'cp-selected' : ''}`}
+                                className={`cp-card-item ${isSelected ? 'cp-selected' : ''} ${card.slabbed ? 'slabbed' : ''}`}
                                 onClick={() => handleClick(card)}
                             >
                                 {isFeatured && <div className="cp-featured-badge">Featured</div>}
@@ -406,6 +408,8 @@ const handleCardClick = (card) => {
                                     description={card.flavorText}
                                     mintNumber={card.mintNumber}
                                     modifier={card.modifier}
+                                    grade={card.grade}
+                                    slabbed={card.slabbed}
                                     maxMint={
                                         rarities.find(
                                             (r) => r.name.toLowerCase() === card.rarity.toLowerCase()

--- a/frontend/src/styles/CollectionPage.css
+++ b/frontend/src/styles/CollectionPage.css
@@ -282,6 +282,11 @@ body {
     align-items: center;
 }
 
+/* Allow slab overlays to extend outside the grid */
+.cp-cards-grid.slabbed {
+    overflow: visible;
+}
+
 /* Card Item */
 .cp-card-item {
     position: relative;
@@ -293,6 +298,12 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+/* Ensure slabbed cards aren't clipped */
+.cp-card-item.slabbed {
+    overflow: visible;
+    z-index: 2;
 }
 
     .cp-card-item:hover {


### PR DESCRIPTION
## Summary
- allow `.slabbed` card overlays to extend beyond the grid
- show slabbed status on Collection page

## Testing
- `npm test -ws --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: ECONNRESET due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6875431681d08330984fe799134b2cef