### PR TITLE
Ensure slab header overlays properly

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -844,6 +844,8 @@
     justify-content: space-between;
     padding: 0 8px;
     pointer-events: none;
+    /* ensure header appears above slab background */
+    z-index: 1;
 }
 
 .slab-logo {


### PR DESCRIPTION
## Summary
- add z-index for the slab header so the card name isn't hidden

## Testing
- `npm test --silent --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68754275a5b88330a355f3ca5d69e489