### PR TITLE
Add slab shine effect and pink header

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -820,6 +820,25 @@
         inset 0 0 4px rgba(0,0,0,0.6);
     pointer-events: none;
     z-index: 8; /* above other rarity effects */
+    overflow: hidden;
+}
+
+.slab-overlay::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(60deg, rgba(255,255,255,0.4), rgba(255,255,255,0) 60%),
+        linear-gradient(-60deg, rgba(255,255,255,0.3), rgba(255,255,255,0) 60%);
+    background-size: 200% 200%;
+    background-repeat: no-repeat;
+    background-position:
+        var(--cursor-x, 50%) var(--cursor-y, 50%),
+        var(--cursor-x, 50%) var(--cursor-y, 50%);
+    mix-blend-mode: screen;
+    transition: background-position 0.1s ease;
+    z-index: 2;
 }
 
 .slab-overlay::before {
@@ -829,8 +848,8 @@
     left: 0;
     right: 0;
     height: 56px;
-    background: var(--slab-border-color);
-    border-bottom: 2px solid var(--slab-border-color);
+    background: hotpink;
+    border-bottom: 2px solid hotpink;
     border-radius: 6px 6px 0 0;
 }
 
@@ -840,7 +859,7 @@
     left: 0;
     right: 0;
     height: 56px;
-    background-color: var(--slab-border-color);
+    background-color: hotpink;
     display: flex;
     align-items: center;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- add shiny cursor-reactive overlay to slab
- make slab header background pink

## Testing
- `npm install` in `frontend`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68755aaf7f4c83308e43c2eb2d6d47f1