### PR TITLE
Fix slab rarity colors

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -2,6 +2,7 @@
 import React, { useRef, useEffect, useState, memo } from 'react';
 import '../styles/CardComponent.css';
 import { rarities } from '../constants/rarities';
+import { getRarityColor } from '../constants/rarityColors';
 import { fetchWithAuth } from '../utils/api';
 
 const BaseCard = ({
@@ -374,7 +375,7 @@ const BaseCard = ({
         <div className="prismatic-overlay" />
       )}
       {slabbed && (
-        <div className="slab-overlay">
+        <div className="slab-overlay" style={{ '--slab-color': getRarityColor(rarity) }}>
           <div className="slab-header">
             <img src="/images/NedsDecksLogo.png" alt="logo" className="slab-logo" />
             <div className="slab-name">{name}</div>

--- a/frontend/src/constants/rarityColors.js
+++ b/frontend/src/constants/rarityColors.js
@@ -1,0 +1,14 @@
+export const rarityColors = {
+  Basic: '#8D8D8D',
+  Common: '#64B5F6',
+  Standard: '#66BB6A',
+  Uncommon: '#1976D2',
+  Rare: '#AB47BC',
+  Epic: '#FFA726',
+  Legendary: '#e32232',
+  Mythic: 'hotpink',
+  Unique: 'black',
+  Divine: 'white',
+};
+
+export const getRarityColor = (rarity) => rarityColors[rarity] || '#fff';

--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -10,6 +10,7 @@
  **************************************/
 .card-container {
     --card-scale: 1;
+    --card-bg-color: #3a2525;
     width: var(--card-width);
     height: var(--card-height);
     aspect-ratio: 2 / 3;
@@ -21,7 +22,7 @@
     font-family: var(--font-family);
     margin: 10px;
     position: relative;
-    background: #3a2525;
+    background: var(--card-bg-color);
     transition: transform 0.1s ease;
     transform-style: preserve-3d;
     will-change: transform;
@@ -177,7 +178,7 @@
 .card-container.slabbed .card-border {
     margin: 0;
     height: 100%;
-    background: #3a2525;
+    background: var(--card-bg-color);
 }
 
 /**************************************
@@ -508,7 +509,7 @@
  **************************************/
 
 .card-container.card-container.unique {
-    background-color: black;
+    --card-bg-color: black;
 }
 
 
@@ -848,8 +849,8 @@
     left: 0;
     right: 0;
     height: 56px;
-    background: hotpink;
-    border-bottom: 2px solid hotpink;
+    background: var(--slab-color, hotpink);
+    border-bottom: 2px solid var(--slab-color, hotpink);
     border-radius: 6px 6px 0 0;
 }
 
@@ -859,7 +860,7 @@
     left: 0;
     right: 0;
     height: 56px;
-    background-color: hotpink;
+    background-color: var(--slab-color, hotpink);
     display: flex;
     align-items: center;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- add `rarityColors` map
- color slab headers to match card rarity
- preserve unique card background when slabbed

## Testing
- `cd frontend && CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68755ed6dd1883308ae0a0bf867196ff