### PR TITLE
Add slabbed card filters

### DIFF
--- a/frontend/src/pages/CollectionPage.js
+++ b/frontend/src/pages/CollectionPage.js
@@ -60,6 +60,7 @@ const CollectionPage = ({
     const [rarityFilter, setRarityFilter] = useState('');
     const [sortOption, setSortOption] = useState('acquiredAt');
     const [order, setOrder] = useState('desc');
+    const [showSlabbedOnly, setShowSlabbedOnly] = useState(false);
 
     // Featured states
     const [featuredCards, setFeaturedCards] = useState([]);
@@ -170,8 +171,13 @@ const CollectionPage = ({
             );
         }
 
+        // Slabbed filter
+        if (showSlabbedOnly) {
+            filtered = filtered.filter((card) => card.slabbed);
+        }
+
         setFilteredCards(filtered);
-    }, [allCards, search, rarityFilter, sortOption, order, showFeaturedOnly, featuredCards]);
+    }, [allCards, search, rarityFilter, sortOption, order, showFeaturedOnly, showSlabbedOnly, featuredCards]);
 
     // Single-click -> select card for deck builder
 const handleCardClick = (card) => {
@@ -325,6 +331,14 @@ const handleCardClick = (card) => {
                                 <option value="asc">Ascending</option>
                                 <option value="desc">Descending</option>
                             </select>
+                            <label className="cp-slabbed-toggle">
+                                <input
+                                    type="checkbox"
+                                    checked={showSlabbedOnly}
+                                    onChange={(e) => setShowSlabbedOnly(e.target.checked)}
+                                />
+                                Slabbed Only
+                            </label>
                         </div>
                     </div>
                     <div className="cp-featured-container">

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -25,10 +25,12 @@ const TradingPage = ({ userId }) => {
     const [leftRarity, setLeftRarity] = useState("");
     const [leftSort, setLeftSort] = useState("acquiredAt");
     const [leftSortDir, setLeftSortDir] = useState("desc");
+    const [leftSlabbedOnly, setLeftSlabbedOnly] = useState(false);
     const [rightSearch, setRightSearch] = useState("");
     const [rightRarity, setRightRarity] = useState("");
     const [rightSort, setRightSort] = useState("acquiredAt");
     const [rightSortDir, setRightSortDir] = useState("desc");
+    const [rightSlabbedOnly, setRightSlabbedOnly] = useState(false);
 
     const [isMobile, setIsMobile] = useState(false);
     const [leftCollapsed, setLeftCollapsed] = useState(false);
@@ -118,11 +120,12 @@ const TradingPage = ({ userId }) => {
         setUserSuggestions([]);
     };
 
-    const applyFilters = (collection, search, rarity, sortBy, sortDir) => {
+    const applyFilters = (collection, search, rarity, sortBy, sortDir, slabbedOnly = false) => {
         return collection
             .filter((card) =>
                 card.name.toLowerCase().includes(search.toLowerCase()) &&
-                (rarity ? card.rarity.toLowerCase() === rarity.toLowerCase() : true)
+                (rarity ? card.rarity.toLowerCase() === rarity.toLowerCase() : true) &&
+                (!slabbedOnly || card.slabbed)
             )
             .sort((a, b) => {
                 let result = 0;
@@ -376,10 +379,18 @@ const TradingPage = ({ userId }) => {
                                                 <option value="asc">Ascending</option>
                                                 <option value="desc">Descending</option>
                                             </select>
+                                            <label className="tp-slabbed-toggle">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={leftSlabbedOnly}
+                                                    onChange={(e) => setLeftSlabbedOnly(e.target.checked)}
+                                                />
+                                                Slabbed Only
+                                            </label>
                                         </div>
                                         <div className="tp-grid-container">
                                             <div className="tp-cards-grid">
-                                                {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir).map((card) => (
+                                                {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir, leftSlabbedOnly).map((card) => (
                                                     <div
                                                         key={card._id}
                                                         className={`tp-card-item ${tradeOffer.some((c) => c._id === card._id) ? "tp-selected" : ""}`}
@@ -439,10 +450,18 @@ const TradingPage = ({ userId }) => {
                                                 <option value="asc">Ascending</option>
                                                 <option value="desc">Descending</option>
                                             </select>
+                                            <label className="tp-slabbed-toggle">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={rightSlabbedOnly}
+                                                    onChange={(e) => setRightSlabbedOnly(e.target.checked)}
+                                                />
+                                                Slabbed Only
+                                            </label>
                                         </div>
                                         <div className="tp-grid-container">
                                             <div className="tp-cards-grid">
-                                                {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir).map((card) => (
+                                                {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir, rightSlabbedOnly).map((card) => (
                                                     <div
                                                         key={card._id}
                                                         className={`tp-card-item ${tradeRequest.some((c) => c._id === card._id) ? "tp-selected" : ""}`}

--- a/frontend/src/styles/CollectionPage.css
+++ b/frontend/src/styles/CollectionPage.css
@@ -216,6 +216,13 @@ body {
     color: var(--text-primary);
 }
 
+.cp-slabbed-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-primary);
+}
+
 .cp-clear-featured-button {
     padding: 8px 16px;
     background-color: var(--brand-primary);

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -135,6 +135,13 @@
     width: 100%;
 }
 
+.tp-slabbed-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-primary);
+}
+
     .tp-filters input[type="text"],
     .tp-filters select {
         background: var(--surface-dark);


### PR DESCRIPTION
## Summary
- add a toggle to filter slabbed cards on collection page
- support slabbed-only filter for both trader collections
- style new filter checkboxes

## Testing
- `npm test` (frontend) *(no tests found)*
- `npm test` (backend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687566cd33dc8330a2b6839e269bc6a8