### PR TITLE
Fix slabbed card spacing

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -46,6 +46,8 @@ const AdminGradingPage = () => {
         }
     };
 
+    const hasSlabbed = cards.some(card => card.slabbed);
+
     return (
         <div className="admin-grading-page">
             <h2>Admin Card Grading</h2>
@@ -59,9 +61,9 @@ const AdminGradingPage = () => {
                 </select>
             </label>
             {loading && <p>Loading cards...</p>}
-            <div className="grading-card-list">
+            <div className={`grading-card-list ${hasSlabbed ? 'slabbed' : ''}`}>
                 {cards.map(card => (
-                    <div key={card._id} className="grading-card-item">
+                    <div key={card._id} className={`grading-card-item ${card.slabbed ? 'slabbed' : ''}`}>
                         <BaseCard
                             name={card.name}
                             image={card.imageUrl}

--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -282,7 +282,7 @@ const MarketListingDetails = () => {
                                     return (
                                         <div
                                             key={card._id}
-                                            className={`market-card-wrapper ${isSelected ? 'selected' : ''}`}
+                                            className={`market-card-wrapper ${isSelected ? 'selected' : ''} ${card.slabbed ? 'slabbed' : ''}`}
                                             onClick={() => toggleCardSelection(card)}
                                         >
                                             <BaseCard
@@ -292,6 +292,8 @@ const MarketListingDetails = () => {
                                                 description={card.flavorText}
                                                 mintNumber={card.mintNumber}
                                                 modifier={card.modifier}
+                                                slabbed={card.slabbed}
+                                                grade={card.grade}
                                             />
                                         </div>
                                     );
@@ -304,7 +306,7 @@ const MarketListingDetails = () => {
                             <div className="market-selected-cards-grid" style={{ '--user-card-scale': 1 }}>
                                 {selectedOfferedCards.length > 0 ? (
                                     selectedOfferedCards.map((card) => (
-                                        <div key={card._id} className="market-card-wrapper">
+                                        <div key={card._id} className={`market-card-wrapper ${card.slabbed ? 'slabbed' : ''}`}> 
                                             <BaseCard
                                                 name={card.name}
                                                 image={card.imageUrl}
@@ -312,6 +314,8 @@ const MarketListingDetails = () => {
                                                 description={card.flavorText}
                                                 mintNumber={card.mintNumber}
                                                 modifier={card.modifier}
+                                                slabbed={card.slabbed}
+                                                grade={card.grade}
                                             />
                                         </div>
                                     ))
@@ -345,7 +349,7 @@ const MarketListingDetails = () => {
                                     <strong>Offered Cards:</strong>
                                     <div className="offered-cards-grid" style={{ '--user-card-scale': 1 }}>
                                         {offer.offeredCards.map(card => (
-                                            <div key={card._id || card.name} className="offered-card-item">
+                                            <div key={card._id || card.name} className={`offered-card-item ${card.slabbed ? 'slabbed' : ''}`}>
                                                 <BaseCard
                                                     name={card.name}
                                                     image={card.imageUrl}
@@ -353,6 +357,8 @@ const MarketListingDetails = () => {
                                                     description={card.flavorText}
                                                     mintNumber={card.mintNumber}
                                                     modifier={card.modifier}
+                                                    slabbed={card.slabbed}
+                                                    grade={card.grade}
                                                 />
                                             </div>
                                         ))}

--- a/frontend/src/pages/TradingPage.js
+++ b/frontend/src/pages/TradingPage.js
@@ -272,7 +272,7 @@ const TradingPage = ({ userId }) => {
                                             {tradeOffer.map((card) => (
                                                 <div
                                                     key={card._id}
-                                                    className="tp-card-item"
+                                                    className={`tp-card-item ${card.slabbed ? 'slabbed' : ''}`}
                                                     onDoubleClick={() => handleRemoveItem(card, "offer")}
                                                     onClick={() => handleSelectItem(card, "offer")}
                                                 >
@@ -284,6 +284,8 @@ const TradingPage = ({ userId }) => {
                                                         mintNumber={card.mintNumber}
                                                         maxMint={rarities.find((r) => r.name === card.rarity)?.totalCopies}
                                                         modifier={card.modifier}
+                                                        slabbed={card.slabbed}
+                                                        grade={card.grade}
                                                     />
                                                 </div>
                                             ))}
@@ -308,7 +310,7 @@ const TradingPage = ({ userId }) => {
                                             {tradeRequest.map((card) => (
                                                 <div
                                                     key={card._id}
-                                                    className="tp-card-item"
+                                                    className={`tp-card-item ${card.slabbed ? 'slabbed' : ''}`}
                                                     onDoubleClick={() => handleRemoveItem(card, "request")}
                                                     onClick={() => handleSelectItem(card, "request")}
                                                 >
@@ -320,6 +322,8 @@ const TradingPage = ({ userId }) => {
                                                         mintNumber={card.mintNumber}
                                                         maxMint={rarities.find((r) => r.name === card.rarity)?.totalCopies}
                                                         modifier={card.modifier}
+                                                        slabbed={card.slabbed}
+                                                        grade={card.grade}
                                                     />
                                                 </div>
                                             ))}
@@ -393,7 +397,7 @@ const TradingPage = ({ userId }) => {
                                                 {applyFilters(userCollection, leftSearch, leftRarity, leftSort, leftSortDir, leftSlabbedOnly).map((card) => (
                                                     <div
                                                         key={card._id}
-                                                        className={`tp-card-item ${tradeOffer.some((c) => c._id === card._id) ? "tp-selected" : ""}`}
+                                                        className={`tp-card-item ${tradeOffer.some((c) => c._id === card._id) ? "tp-selected" : ""} ${card.slabbed ? 'slabbed' : ''}`}
                                                         onClick={() => handleSelectItem(card, "offer")}
                                                     >
                                                         <BaseCard
@@ -404,6 +408,8 @@ const TradingPage = ({ userId }) => {
                                                             mintNumber={card.mintNumber}
                                                             maxMint={rarities.find((r) => r.name === card.rarity)?.totalCopies}
                                                             modifier={card.modifier}
+                                                            slabbed={card.slabbed}
+                                                            grade={card.grade}
                                                         />
                                                     </div>
                                                 ))}
@@ -464,7 +470,7 @@ const TradingPage = ({ userId }) => {
                                                 {applyFilters(recipientCollection, rightSearch, rightRarity, rightSort, rightSortDir, rightSlabbedOnly).map((card) => (
                                                     <div
                                                         key={card._id}
-                                                        className={`tp-card-item ${tradeRequest.some((c) => c._id === card._id) ? "tp-selected" : ""}`}
+                                                        className={`tp-card-item ${tradeRequest.some((c) => c._id === card._id) ? "tp-selected" : ""} ${card.slabbed ? 'slabbed' : ''}`}
                                                         onClick={() => handleSelectItem(card, "request")}
                                                     >
                                                         <BaseCard
@@ -475,6 +481,8 @@ const TradingPage = ({ userId }) => {
                                                             mintNumber={card.mintNumber}
                                                             maxMint={rarities.find((r) => r.name === card.rarity)?.totalCopies}
                                                             modifier={card.modifier}
+                                                            slabbed={card.slabbed}
+                                                            grade={card.grade}
                                                         />
                                                     </div>
                                                 ))}

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -24,10 +24,20 @@
     justify-items: center;
 }
 
+.grading-card-list.slabbed {
+    overflow: visible;
+}
+
 .grading-card-item {
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+/* Additional space when showing slab overlay */
+.grading-card-item.slabbed {
+    overflow: visible;
+    margin: 72px 30px 24px;
 }
 
 .grading-card-item button {

--- a/frontend/src/styles/CollectionPage.css
+++ b/frontend/src/styles/CollectionPage.css
@@ -311,6 +311,7 @@ body {
 .cp-card-item.slabbed {
     overflow: visible;
     z-index: 2;
+    margin: 72px 30px 24px;
 }
 
     .cp-card-item:hover {

--- a/frontend/src/styles/MarketListingDetails.css
+++ b/frontend/src/styles/MarketListingDetails.css
@@ -123,6 +123,11 @@
         transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
 
+        .market-user-collection-grid .market-card-wrapper.slabbed {
+            overflow: visible;
+            margin: 72px 30px 24px;
+        }
+
 
         .market-user-collection-grid .market-card-wrapper.selected {
             border: 2px solid var(--brand-primary);
@@ -221,6 +226,11 @@
 .offered-card-item {
     flex: 1 1 250px;
     max-width: 250px;
+}
+
+.offered-card-item.slabbed {
+    overflow: visible;
+    margin: 72px 30px 24px;
 }
 
 /* Fix invisible cards in market listing */

--- a/frontend/src/styles/TradingPage.css
+++ b/frontend/src/styles/TradingPage.css
@@ -262,6 +262,12 @@
     align-items: center;
 }
 
+/* Extra spacing for slabbed cards */
+.tp-card-item.slabbed {
+    overflow: visible;
+    margin: 72px 30px 24px;
+}
+
     .tp-card-item:hover {
         transform: scale(1.1);
         border-color: var(--border-dark);


### PR DESCRIPTION
## Summary
- add margin and overflow settings for slabbed cards across all grids
- include slabbed status in trading and market pages
- support slabbed card display in admin grading page

## Testing
- `cd frontend && CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68756b7c61e88330988c5434c86f2601