### PR TITLE
Fix divine slab background art

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -172,6 +172,9 @@
 /* Allow slab overlay to extend above the card */
 .card-container.slabbed {
     overflow: visible;
+}
+
+.card-container.slabbed:not(.divine) {
     background: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure Divine cards retain background art when slabbed

## Testing
- `npm test --silent` (frontend: no tests found)
- `npm test --silent` in `backend` (prints 'Error: no test specified')

------
https://chatgpt.com/codex/tasks/task_e_68777ef264748330801bace2b60b785f