### PR TITLE
Fix divine slab art visibility

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -184,6 +184,11 @@
     background: var(--card-bg-color);
 }
 
+/* Don't cover divine background when slabbed */
+.card-container.slabbed.divine .card-border {
+    background: none;
+}
+
 /**************************************
  * Glare for Lower Rarities (Basic → Uncommon)
  * Now matches the border color with alpha


### PR DESCRIPTION
## Summary
- ensure divine card artwork background remains visible when card is slabbed

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6877824abc848330aa2a364d5c71c8c5