### PR TITLE
Enhance admin grading UI

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth, gradeCard } from '../utils/api';
 import BaseCard from '../components/BaseCard';
+import { rarities } from '../constants/rarities';
 import '../styles/AdminGradingPage.css';
 
 const AdminGradingPage = () => {
@@ -8,6 +9,13 @@ const AdminGradingPage = () => {
     const [selectedUser, setSelectedUser] = useState('');
     const [cards, setCards] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [rarityFilter, setRarityFilter] = useState('All');
+    const [sortOption, setSortOption] = useState('name');
+    const [showSlabbedOnly, setShowSlabbedOnly] = useState(false);
+
+    const [gradingCard, setGradingCard] = useState(null);
+    const [revealGrade, setRevealGrade] = useState(false);
 
     useEffect(() => {
         const loadUsers = async () => {
@@ -41,10 +49,36 @@ const AdminGradingPage = () => {
             await gradeCard(selectedUser, cardId);
             const data = await fetchWithAuth(`/api/users/${selectedUser}/collection`);
             setCards(data.cards || []);
+            const graded = (data.cards || []).find(c => c._id === cardId);
+            if (graded) {
+                setGradingCard(graded);
+                setRevealGrade(false);
+            }
         } catch (err) {
             console.error('Error grading card', err);
         }
     };
+
+    const rarityRank = rarities.reduce((acc, r, idx) => {
+        acc[r.name] = idx;
+        return acc;
+    }, {});
+
+    const filteredCards = cards
+        .filter(card => card.name.toLowerCase().includes(searchQuery.toLowerCase()))
+        .filter(card => rarityFilter === 'All' || card.rarity === rarityFilter)
+        .filter(card => (showSlabbedOnly ? card.slabbed : true));
+
+    const sortedCards = [...filteredCards].sort((a, b) => {
+        if (sortOption === 'mint') {
+            return a.mintNumber - b.mintNumber;
+        }
+        if (sortOption === 'rarity') {
+            return rarityRank[a.rarity] - rarityRank[b.rarity];
+        }
+        // default name sort
+        return a.name.localeCompare(b.name);
+    });
 
     const hasSlabbed = cards.some(card => card.slabbed);
 
@@ -53,16 +87,81 @@ const AdminGradingPage = () => {
             <h2>Admin Card Grading</h2>
             <label>
                 Select User:
-                <select value={selectedUser} onChange={handleSelectUser}>
+                <select value={selectedUser} onChange={handleSelectUser} data-testid="user-select">
                     <option value="">-- choose user --</option>
                     {users.map(u => (
                         <option key={u._id} value={u._id}>{u.username}</option>
                     ))}
                 </select>
             </label>
+
+            {selectedUser && (
+                <div className="grading-controls">
+                    <input
+                        type="text"
+                        placeholder="Search"
+                        value={searchQuery}
+                        onChange={e => setSearchQuery(e.target.value)}
+                        data-testid="search-input"
+                    />
+                    <select value={rarityFilter} onChange={e => setRarityFilter(e.target.value)} data-testid="rarity-select">
+                        <option value="All">All Rarities</option>
+                        {rarities.map(r => (
+                            <option key={r.name} value={r.name}>{r.name}</option>
+                        ))}
+                    </select>
+                    <label className="slab-toggle">
+                        <input
+                            type="checkbox"
+                            checked={showSlabbedOnly}
+                            onChange={e => setShowSlabbedOnly(e.target.checked)}
+                            data-testid="slab-toggle"
+                        />
+                        Show Slabbed Only
+                    </label>
+                    <select value={sortOption} onChange={e => setSortOption(e.target.value)} data-testid="sort-select">
+                        <option value="name">Name</option>
+                        <option value="mint">Mint #</option>
+                        <option value="rarity">Rarity</option>
+                    </select>
+                </div>
+            )}
+
+            {gradingCard && (
+                <div className="grading-area" data-testid="grading-area">
+                    <h3>Graded Card</h3>
+                    <div
+                        className={`card-wrapper ${revealGrade ? 'face-up' : 'face-down'}`}
+                        onClick={() => setRevealGrade(r => !r)}
+                        style={{ '--rarity-color': 'white' }}
+                        data-testid="graded-card-wrapper"
+                    >
+                        <div className="card-content">
+                            <div className="card-inner">
+                                <div className="card-back">
+                                    <img src="/images/card-back-placeholder.png" alt="Card Back" />
+                                </div>
+                                <div className="card-front">
+                                    <BaseCard
+                                        name={gradingCard.name}
+                                        image={gradingCard.imageUrl}
+                                        description={gradingCard.flavorText}
+                                        rarity={gradingCard.rarity}
+                                        mintNumber={gradingCard.mintNumber}
+                                        modifier={gradingCard.modifier}
+                                        grade={gradingCard.grade}
+                                        slabbed={gradingCard.slabbed}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+
             {loading && <p>Loading cards...</p>}
             <div className={`grading-card-list ${hasSlabbed ? 'slabbed' : ''}`}>
-                {cards.map(card => (
+                {sortedCards.map(card => (
                     <div key={card._id} className={`grading-card-item ${card.slabbed ? 'slabbed' : ''}`}>
                         <BaseCard
                             name={card.name}
@@ -75,7 +174,7 @@ const AdminGradingPage = () => {
                             slabbed={card.slabbed}
                         />
                         {!card.slabbed && (
-                            <button onClick={() => handleGrade(card._id)}>Grade</button>
+                            <button onClick={() => handleGrade(card._id)} data-testid={`grade-btn-${card._id}`}>Grade</button>
                         )}
                         {card.slabbed && <span>Grade: {card.grade}</span>}
                     </div>

--- a/frontend/src/pages/__tests__/AdminGradingPage.test.js
+++ b/frontend/src/pages/__tests__/AdminGradingPage.test.js
@@ -1,8 +1,56 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import AdminGradingPage from '../AdminGradingPage';
+import { fetchWithAuth, gradeCard } from '../../utils/api';
 
-test('renders grading page heading', () => {
-  const { getByText } = render(<AdminGradingPage />);
-  const heading = getByText(/Admin Card Grading/i);
-  expect(heading).not.toBeNull();
+jest.mock('../../utils/api');
+
+const mockUsers = [{ _id: '1', username: 'Alice' }];
+const mockCards = [
+  { _id: 'c1', name: 'Alpha', rarity: 'Common', mintNumber: 10, slabbed: false },
+  { _id: 'c2', name: 'Beta', rarity: 'Rare', mintNumber: 5, slabbed: true, grade: 8 },
+];
+
+beforeEach(() => {
+  fetchWithAuth.mockReset();
+  gradeCard.mockReset();
+  fetchWithAuth.mockImplementation((endpoint) => {
+    if (endpoint === '/api/admin/users') return Promise.resolve(mockUsers);
+    if (endpoint === '/api/users/1/collection') return Promise.resolve({ cards: mockCards });
+    return Promise.resolve({});
+  });
+});
+
+test('filters cards by search and rarity', async () => {
+  const { getByTestId, queryByText } = render(<AdminGradingPage />);
+  const select = getByTestId('user-select');
+  await waitFor(() => select.querySelector('option[value="1"]'));
+  fireEvent.change(select, { target: { value: '1' } });
+  await waitFor(() => getByTestId('search-input'));
+
+  fireEvent.change(getByTestId('search-input'), { target: { value: 'Alpha' } });
+  expect(queryByText('Beta')).toBeNull();
+
+  fireEvent.change(getByTestId('rarity-select'), { target: { value: 'Rare' } });
+  expect(queryByText('Alpha')).toBeNull();
+});
+
+test('grading workflow reveals card', async () => {
+  const updatedCards = [{ ...mockCards[0], slabbed: true, grade: 9 }, mockCards[1]];
+  fetchWithAuth.mockImplementationOnce(() => Promise.resolve(mockUsers))
+    .mockImplementationOnce(() => Promise.resolve({ cards: mockCards }))
+    .mockImplementationOnce(() => Promise.resolve({ cards: updatedCards }));
+
+  const { getByTestId } = render(<AdminGradingPage />);
+  const select = getByTestId('user-select');
+  await waitFor(() => select.querySelector('option[value="1"]'));
+  fireEvent.change(select, { target: { value: '1' } });
+  await waitFor(() => getByTestId('grade-btn-c1'));
+
+  fireEvent.click(getByTestId('grade-btn-c1'));
+  await waitFor(() => getByTestId('graded-card-wrapper'));
+
+  const wrapper = getByTestId('graded-card-wrapper');
+  expect(wrapper.className).toContain('face-down');
+  fireEvent.click(wrapper);
+  expect(wrapper.className).toContain('face-up');
 });

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -55,3 +55,83 @@
     background: var(--brand-secondary);
     transform: scale(1.05);
 }
+
+/* Controls */
+.grading-controls {
+    margin: 1rem 0 2rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+}
+
+.grading-controls input,
+.grading-controls select {
+    padding: 0.5rem 0.75rem;
+    background: var(--surface-darker);
+    border: 1px solid var(--border-dark);
+    color: var(--text-primary);
+    border-radius: var(--border-radius);
+}
+
+/* Grading reveal area */
+.grading-area {
+    margin: 2rem 0;
+    text-align: center;
+}
+
+.grading-area h3 {
+    margin-bottom: 1rem;
+}
+
+.card-wrapper {
+    transition: transform 0.6s ease;
+    cursor: pointer;
+    width: 300px;
+    margin: 0 auto;
+}
+
+.face-down .card-inner {
+    transform: rotateY(0deg);
+}
+
+.face-up .card-inner {
+    transform: rotateY(180deg);
+}
+
+.card-content {
+    perspective: 1000px;
+}
+
+.card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    transition: transform 0.6s ease;
+}
+
+.card-back,
+.card-front {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border-radius: var(--border-radius);
+}
+
+.card-back img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--border-radius);
+}
+
+.card-front {
+    transform: rotateY(180deg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- add card filtering, sorting and reveal state
- support suspenseful grade flip animation
- style grading controls and reveal area
- extend tests for filtering and grading workflow

## Testing
- `cd frontend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68779ed08fe88330a9d416b698f30f1e