### PR TITLE
Improve grading layout & spinner

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithAuth, gradeCard } from '../utils/api';
 import BaseCard from '../components/BaseCard';
+import LoadingSpinner from '../components/LoadingSpinner';
 import { rarities } from '../constants/rarities';
 import '../styles/AdminGradingPage.css';
 
@@ -9,6 +10,7 @@ const AdminGradingPage = () => {
     const [selectedUser, setSelectedUser] = useState('');
     const [cards, setCards] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [gradingLoading, setGradingLoading] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const [rarityFilter, setRarityFilter] = useState('All');
     const [sortOption, setSortOption] = useState('name');
@@ -45,6 +47,7 @@ const AdminGradingPage = () => {
     };
 
     const handleGrade = async (cardId) => {
+        setGradingLoading(true);
         try {
             await gradeCard(selectedUser, cardId);
             const data = await fetchWithAuth(`/api/users/${selectedUser}/collection`);
@@ -56,6 +59,8 @@ const AdminGradingPage = () => {
             }
         } catch (err) {
             console.error('Error grading card', err);
+        } finally {
+            setGradingLoading(false);
         }
     };
 
@@ -84,6 +89,7 @@ const AdminGradingPage = () => {
 
     return (
         <div className="admin-grading-page">
+            {gradingLoading && <LoadingSpinner />}
             <h2>Admin Card Grading</h2>
             <label>
                 Select User:

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -78,18 +78,17 @@
 
 /* Layout split */
 .grading-layout {
-    flex: 1;
     display: flex;
     flex-direction: column;
 }
 
 .collection-section {
-    flex: 1;
+    height: 50vh;
     overflow-y: auto;
 }
 
 .reveal-zone {
-    flex: 1;
+    height: 50vh;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- show top/bottom sections at half viewport height
- show spinner while grading a card

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bd17c3348330a3e9c6294efdbc11