### PR TITLE
Fix grading page layout

### DIFF
--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -78,17 +78,18 @@
 
 /* Layout split */
 .grading-layout {
+    flex: 1;
     display: flex;
     flex-direction: column;
 }
 
 .collection-section {
-    height: 50vh;
+    flex: 1;
     overflow-y: auto;
 }
 
 .reveal-zone {
-    height: 50vh;
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- revert height-locked layout for Admin grading page
- ensure bottom reveal area shows graded card

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6877d3747a8c83309b1a4e6c37d22bd4