### PR TITLE
Improve slab back flip styling

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -3,6 +3,7 @@ import { fetchWithAuth, gradeCard } from '../utils/api';
 import BaseCard from '../components/BaseCard';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { rarities } from '../constants/rarities';
+import { getRarityColor } from '../constants/rarityColors';
 import '../styles/AdminGradingPage.css';
 
 const AdminGradingPage = () => {
@@ -16,7 +17,8 @@ const AdminGradingPage = () => {
     const [sortOption, setSortOption] = useState('name');
     const [showSlabbedOnly, setShowSlabbedOnly] = useState(false);
 
-    const [gradingCard, setGradingCard] = useState(null);
+    const [selectedCard, setSelectedCard] = useState(null);
+    const [gradedCard, setGradedCard] = useState(null);
     const [revealGrade, setRevealGrade] = useState(false);
 
     useEffect(() => {
@@ -46,15 +48,23 @@ const AdminGradingPage = () => {
         }
     };
 
-    const handleGrade = async (cardId) => {
+    const handleSelectCard = (card) => {
+        setSelectedCard(card);
+        setGradedCard(null);
+        setRevealGrade(false);
+    };
+
+    const handleGrade = async () => {
+        if (!selectedCard) return;
         setGradingLoading(true);
         try {
-            await gradeCard(selectedUser, cardId);
+            await gradeCard(selectedUser, selectedCard._id);
             const data = await fetchWithAuth(`/api/users/${selectedUser}/collection`);
             setCards(data.cards || []);
-            const graded = (data.cards || []).find(c => c._id === cardId);
+            const graded = (data.cards || []).find(c => c._id === selectedCard._id);
             if (graded) {
-                setGradingCard(graded);
+                setGradedCard(graded);
+                setSelectedCard(null);
                 setRevealGrade(false);
             }
         } catch (err) {
@@ -134,12 +144,11 @@ const AdminGradingPage = () => {
             )}
 
             <div className="grading-layout">
-                <div className="collection-section">
-                    {loading && <p>Loading cards...</p>}
-                    <div className={`grading-card-list ${hasSlabbed ? 'slabbed' : ''}`}>
-                    {sortedCards
-                        .filter(card => !gradingCard || card._id !== gradingCard._id)
-                        .map(card => (
+                {!selectedCard && !gradedCard && (
+                    <div className="collection-section" data-testid="collection-list">
+                        {loading && <p>Loading cards...</p>}
+                        <div className={`grading-card-list ${hasSlabbed ? 'slabbed' : ''}`}>
+                        {sortedCards.map(card => (
                             <div key={card._id} className={`grading-card-item ${card.slabbed ? 'slabbed' : ''}`}>
                                 <BaseCard
                                     name={card.name}
@@ -152,49 +161,64 @@ const AdminGradingPage = () => {
                                     slabbed={card.slabbed}
                                 />
                                 {!card.slabbed && (
-                                    <button onClick={() => handleGrade(card._id)} data-testid={`grade-btn-${card._id}`}>Grade</button>
+                                    <button onClick={() => handleSelectCard(card)} data-testid={`select-btn-${card._id}`}>Select</button>
                                 )}
                                 {card.slabbed && <span>Grade: {card.grade}</span>}
                             </div>
                         ))}
+                        </div>
                     </div>
-                </div>
-                <div className="reveal-zone">
-                    {gradingCard ? (
-                        <div className="grading-area" data-testid="grading-area">
-                            <div
-                                className={`card-wrapper ${revealGrade ? 'face-up' : 'face-down'}`}
-                                onClick={() => setRevealGrade(r => !r)}
-                                style={{ '--rarity-color': 'white' }}
-                                data-testid="graded-card-wrapper"
-                            >
-                                <div className="card-content">
-                                    <div className="card-inner">
-                                        <div className="card-back">
-                                            <img src="/images/card-back-placeholder.png" alt="Card Back" />
-                                        </div>
-                                        <div className="card-front">
-                                            <BaseCard
-                                                name={gradingCard.name}
-                                                image={gradingCard.imageUrl}
-                                                description={gradingCard.flavorText}
-                                                rarity={gradingCard.rarity}
-                                                mintNumber={gradingCard.mintNumber}
-                                                modifier={gradingCard.modifier}
-                                                grade={gradingCard.grade}
-                                                slabbed={gradingCard.slabbed}
-                                            />
-                                        </div>
+                )}
+                {selectedCard && (
+                    <div className="reveal-zone" data-testid="selected-card-area">
+                        <div className="grading-area">
+                            <BaseCard
+                                name={selectedCard.name}
+                                image={selectedCard.imageUrl}
+                                description={selectedCard.flavorText}
+                                rarity={selectedCard.rarity}
+                                mintNumber={selectedCard.mintNumber}
+                                modifier={selectedCard.modifier}
+                                grade={selectedCard.grade}
+                                slabbed={selectedCard.slabbed}
+                            />
+                            {!selectedCard.slabbed && (
+                                <button onClick={handleGrade} data-testid="grade-btn">Grade Card</button>
+                            )}
+                        </div>
+                    </div>
+                )}
+                {gradedCard && (
+                    <div className="reveal-zone" data-testid="grading-area">
+                        <div
+                            className={`card-wrapper ${revealGrade ? 'face-up' : 'face-down'}`}
+                            onClick={() => setRevealGrade(r => !r)}
+                            style={{ '--rarity-color': getRarityColor(gradedCard.rarity) }}
+                            data-testid="graded-card-wrapper"
+                        >
+                            <div className="card-content">
+                                <div className="card-inner">
+                                    <div className="card-back">
+                                        <img src="/images/card-back-placeholder.png" alt="Card Back" />
+                                        <div className="slab-back-overlay" style={{ '--slab-color': getRarityColor(gradedCard.rarity) }} />
+                                    </div>
+                                    <div className="card-front">
+                                        <BaseCard
+                                            name={gradedCard.name}
+                                            image={gradedCard.imageUrl}
+                                            description={gradedCard.flavorText}
+                                            rarity={gradedCard.rarity}
+                                            mintNumber={gradedCard.mintNumber}
+                                            modifier={gradedCard.modifier}
+                                            grade={gradedCard.grade}
+                                            slabbed={gradedCard.slabbed}
+                                        />
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    ) : (
-                        <div className="grading-area" data-testid="grading-area">
-                            <p>Select a card to grade</p>
-                        </div>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/pages/__tests__/AdminGradingPage.test.js
+++ b/frontend/src/pages/__tests__/AdminGradingPage.test.js
@@ -40,13 +40,17 @@ test('grading workflow reveals card', async () => {
     .mockImplementationOnce(() => Promise.resolve({ cards: mockCards }))
     .mockImplementationOnce(() => Promise.resolve({ cards: updatedCards }));
 
-  const { getByTestId } = render(<AdminGradingPage />);
+  const { getByTestId, queryByTestId } = render(<AdminGradingPage />);
   const select = getByTestId('user-select');
   await waitFor(() => select.querySelector('option[value="1"]'));
   fireEvent.change(select, { target: { value: '1' } });
-  await waitFor(() => getByTestId('grade-btn-c1'));
+  await waitFor(() => getByTestId('select-btn-c1'));
 
-  fireEvent.click(getByTestId('grade-btn-c1'));
+  fireEvent.click(getByTestId('select-btn-c1'));
+  await waitFor(() => getByTestId('selected-card-area'));
+  expect(queryByTestId('collection-list')).toBeNull();
+
+  fireEvent.click(getByTestId('grade-btn'));
   await waitFor(() => getByTestId('graded-card-wrapper'));
 
   const wrapper = getByTestId('graded-card-wrapper');

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -109,6 +109,7 @@
     transition: transform 0.6s ease;
     cursor: pointer;
     width: 300px;
+    height: 450px;
     margin: 0 auto;
 }
 
@@ -121,7 +122,11 @@
 }
 
 .card-content {
+    width: 300px;
+    aspect-ratio: 2 / 3;
+    position: relative;
     perspective: 1000px;
+    overflow: visible;
 }
 
 .card-inner {
@@ -143,6 +148,11 @@
     border-radius: var(--border-radius);
 }
 
+.card-back {
+    transform: rotateY(0deg);
+    z-index: 2;
+}
+
 .card-back img {
     width: 100%;
     height: 100%;
@@ -155,4 +165,54 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    z-index: 1;
+}
+
+.slab-back-overlay {
+    position: absolute;
+    top: -72px;
+    left: -30px;
+    right: -30px;
+    bottom: -24px;
+    border-radius: 10px;
+    --slab-border-color: rgba(255, 255, 255, 0.9);
+    border: 12px solid var(--slab-border-color);
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow:
+        0 4px 8px rgba(0,0,0,0.6),
+        inset 0 0 12px rgba(255,255,255,0.5),
+        inset 0 0 4px rgba(0,0,0,0.6);
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 8;
+}
+
+.slab-back-overlay::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    background: var(--slab-color, hotpink);
+    border-bottom: 2px solid var(--slab-color, hotpink);
+    border-radius: 6px 6px 0 0;
+}
+
+.slab-back-overlay::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(60deg, rgba(255,255,255,0.4), rgba(255,255,255,0) 60%),
+        linear-gradient(-60deg, rgba(255,255,255,0.3), rgba(255,255,255,0) 60%);
+    background-size: 200% 200%;
+    background-repeat: no-repeat;
+    background-position:
+        var(--cursor-x, 50%) var(--cursor-y, 50%),
+        var(--cursor-x, 50%) var(--cursor-y, 50%);
+    mix-blend-mode: screen;
+    transition: background-position 0.1s ease;
+    z-index: 2;
 }


### PR DESCRIPTION
## Summary
- style the slab's back overlay with a colored header
- show the graded card face-down using its rarity color for hover glow
- ensure the card back image is visible with 300x450 sizing

## Testing
- `npm --prefix frontend install --silent`
- `CI=true npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877d88bffbc8330b121484086d842cb