### PR TITLE
Implement grading timer and override

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,5 @@ Refer to [`backend/README_trading_market.md`](backend/README_trading_market.md) 
 
 ## Card Grading (Admin Only)
 
-Admins can grade any card from the `/admin/grading` page. Selecting a user and card will assign a random grade from 1–10 and mark the card as slabbed. Graded cards display a plastic "slab" overlay with the project logo and grade value.
+Admins can initiate grading for any card from the `/admin/grading` page. Once started, grading takes 24 hours to complete unless an admin overrides the timer. When finished, the card is slabbed with a random grade from 1–10 and displays a plastic "slab" overlay with the grade value.
 

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -17,6 +17,7 @@ const cardSchema = new mongoose.Schema({
     grade: { type: Number, min: 1, max: 10 },
     slabbed: { type: Boolean, default: false },
     gradedAt: Date,
+    gradingRequestedAt: Date,
 });
 
 // Index nested card id for faster $elemMatch queries

--- a/backend/src/routes/gradingRoutes.js
+++ b/backend/src/routes/gradingRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
-const { gradeCard } = require('../controllers/gradingController');
+const { startGrading, completeGrading } = require('../controllers/gradingController');
 
 const router = express.Router();
 
-router.post('/grade-card', protect, adminOnly, gradeCard);
+router.post('/grade-card', protect, adminOnly, startGrading);
+router.post('/grade-card/complete', protect, adminOnly, completeGrading);
 
 module.exports = router;

--- a/frontend/src/pages/__tests__/AdminGradingPage.test.js
+++ b/frontend/src/pages/__tests__/AdminGradingPage.test.js
@@ -34,13 +34,13 @@ test('filters cards by search and rarity', async () => {
   expect(queryByText('Alpha')).toBeNull();
 });
 
-test('grading workflow reveals card', async () => {
-  const updatedCards = [{ ...mockCards[0], slabbed: true, grade: 9 }, mockCards[1]];
+test('grading workflow moves card to in-progress list', async () => {
+  const inProcess = [{ ...mockCards[0], gradingRequestedAt: new Date().toISOString() }, mockCards[1]];
   fetchWithAuth.mockImplementationOnce(() => Promise.resolve(mockUsers))
     .mockImplementationOnce(() => Promise.resolve({ cards: mockCards }))
-    .mockImplementationOnce(() => Promise.resolve({ cards: updatedCards }));
+    .mockImplementationOnce(() => Promise.resolve({ cards: inProcess }));
 
-  const { getByTestId, queryByTestId } = render(<AdminGradingPage />);
+  const { getByTestId } = render(<AdminGradingPage />);
   const select = getByTestId('user-select');
   await waitFor(() => select.querySelector('option[value="1"]'));
   fireEvent.change(select, { target: { value: '1' } });
@@ -48,13 +48,8 @@ test('grading workflow reveals card', async () => {
 
   fireEvent.click(getByTestId('select-btn-c1'));
   await waitFor(() => getByTestId('selected-card-area'));
-  expect(queryByTestId('collection-list')).toBeNull();
 
   fireEvent.click(getByTestId('grade-btn'));
-  await waitFor(() => getByTestId('graded-card-wrapper'));
-
-  const wrapper = getByTestId('graded-card-wrapper');
-  expect(wrapper.className).toContain('face-up');
-  fireEvent.click(wrapper);
-  expect(wrapper.className).toContain('face-down');
+  await waitFor(() => getByTestId('inprocess-list'));
+  expect(getByTestId('inprocess-list')).toBeDefined();
 });

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -34,6 +34,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    position: relative;
 }
 
 /* Additional space when showing slab overlay */
@@ -215,5 +216,22 @@
         var(--cursor-x, 50%) var(--cursor-y, 50%);
     mix-blend-mode: screen;
     transition: background-position 0.1s ease;
+    z-index: 2;
+}
+
+.inprocess-section {
+    margin-bottom: 2rem;
+}
+
+.grading-timeleft-badge {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(0, 0, 0, 0.541);
+    color: #d4d0c0;
+    border-radius: 6px;
+    padding: 4px 9px;
+    font-size: 1rem;
+    font-weight: bold;
     z-index: 2;
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -440,7 +440,19 @@ export const gradeCard = async (userId, cardId) => {
             body: JSON.stringify({ userId, cardId }),
         });
     } catch (error) {
-        console.error('[API] Error grading card:', error.message);
+        console.error('[API] Error starting grading:', error.message);
+        throw error;
+    }
+};
+
+export const completeGrading = async (userId, cardId) => {
+    try {
+        return await fetchWithAuth('/api/grading/grade-card/complete', {
+            method: 'POST',
+            body: JSON.stringify({ userId, cardId }),
+        });
+    } catch (error) {
+        console.error('[API] Error completing grading:', error.message);
         throw error;
     }
 };


### PR DESCRIPTION
## Summary
- add 24‑hour grading workflow with override
- track grading start time in user card model
- finalize grading when time elapses or admin overrides
- show cards in grading with countdown on admin grading page
- adjust tests for new grading flow

## Testing
- `CI=true npm test --silent`
- `npm test --silent` (backend)

------
https://chatgpt.com/codex/tasks/task_e_687929aaa80c8330938f571960bca123