### PR TITLE
Keep graded cards in reveal queue

### DIFF
--- a/backend/src/controllers/gradingController.js
+++ b/backend/src/controllers/gradingController.js
@@ -16,7 +16,11 @@ const finalizeGrade = (card) => {
     card.grade = grade;
     card.slabbed = true;
     card.gradedAt = new Date();
-    card.gradingRequestedAt = undefined;
+    // Keep gradingRequestedAt so the frontend knows this card's
+    // grade has not been revealed yet. Previously the field was
+    // cleared which caused the card to immediately move back to
+    // the collection list. Retaining it allows the card to stay
+    // in the "grading" section until manually revealed.
 };
 
 const startGrading = async (req, res) => {


### PR DESCRIPTION
## Summary
- retain `gradingRequestedAt` when finalizing grades
- track revealed cards and allow flipping in Admin grading page
- show slabbed cards face-down until clicked

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68792d66a694833094835e2cc03a9e5c