### PR TITLE
Add reveal completion workflow

### DIFF
--- a/backend/src/controllers/gradingController.js
+++ b/backend/src/controllers/gradingController.js
@@ -67,4 +67,23 @@ const completeGrading = async (req, res) => {
     }
 };
 
-module.exports = { startGrading, completeGrading, finalizeGrade };
+const revealGradedCard = async (req, res) => {
+    const { userId, cardId } = req.body;
+    if (!userId || !cardId) {
+        return res.status(400).json({ message: 'userId and cardId are required' });
+    }
+    try {
+        const user = await User.findById(userId);
+        if (!user) return res.status(404).json({ message: 'User not found' });
+        const card = user.cards.id(cardId);
+        if (!card) return res.status(404).json({ message: 'Card not found' });
+        card.gradingRequestedAt = undefined;
+        await user.save();
+        res.json({ card });
+    } catch (err) {
+        console.error('Error revealing grade:', err);
+        res.status(500).json({ message: 'Failed to reveal grade' });
+    }
+};
+
+module.exports = { startGrading, completeGrading, finalizeGrade, revealGradedCard };

--- a/backend/src/routes/gradingRoutes.js
+++ b/backend/src/routes/gradingRoutes.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
-const { startGrading, completeGrading } = require('../controllers/gradingController');
+const { startGrading, completeGrading, revealGradedCard } = require('../controllers/gradingController');
 
 const router = express.Router();
 
 router.post('/grade-card', protect, adminOnly, startGrading);
 router.post('/grade-card/complete', protect, adminOnly, completeGrading);
+router.post('/grade-card/reveal', protect, adminOnly, revealGradedCard);
 
 module.exports = router;

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -59,6 +59,10 @@
     transform: scale(1.05);
 }
 
+.done-btn {
+    margin-top: 0.5rem;
+}
+
 /* Controls */
 .grading-controls {
     margin: 1rem 0 2rem;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -456,3 +456,15 @@ export const completeGrading = async (userId, cardId) => {
         throw error;
     }
 };
+
+export const revealGradedCard = async (userId, cardId) => {
+    try {
+        return await fetchWithAuth('/api/grading/grade-card/reveal', {
+            method: 'POST',
+            body: JSON.stringify({ userId, cardId }),
+        });
+    } catch (error) {
+        console.error('[API] Error revealing grade:', error.message);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- filter graded cards from selection list
- allow admins to clear the `gradingRequestedAt` field after revealing a card
- expose API helper for revealing a graded card
- show a `Done` button when a card has been revealed

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687a33c528188330af20ca70fe4bbee3