### PR TITLE
Enable rotation on slabbed cards post grading

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -219,7 +219,7 @@ const AdminGradingPage = () => {
                                                                         modifier={card.modifier}
                                                                         grade={card.grade}
                                                                         slabbed={card.slabbed}
-                                                                        interactive={false}
+                                                                        interactive={faceUp}
                                                                     />
                                                                 </div>
                                                             </div>


### PR DESCRIPTION
## Summary
- allow interactive 3D tilt on graded cards that are being revealed

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687a641724408330be925f707a52cf55