### PR TITLE
Fix reveal card toggle

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -107,10 +107,14 @@ const AdminGradingPage = () => {
     };
 
     const toggleReveal = (cardId) => {
-        setRevealedCards((prev) => ({
-            ...prev,
-            [cardId]: !prev[cardId],
-        }));
+        setRevealedCards((prev) => {
+            // Only allow flipping from face-down to face-up once
+            if (prev[cardId]) return prev;
+            return {
+                ...prev,
+                [cardId]: true,
+            };
+        });
     };
 
     const rarityRank = rarities.reduce((acc, r, idx) => {
@@ -237,6 +241,7 @@ const AdminGradingPage = () => {
                                                                         grade={card.grade}
                                                                         slabbed={card.slabbed}
                                                                         interactive={faceUp}
+                                                                        inspectOnClick={faceUp}
                                                                     />
                                                                 </div>
                                                             </div>


### PR DESCRIPTION
## Summary
- ensure grading page doesn't un-flip a graded card when inspected
- only allow inspecting once flipped face up

## Testing
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687bc747224c8330a57f74b6e2b6c98d