### PR TITLE
Fix listing of graded cards

### DIFF
--- a/backend/src/models/MarketListing.js
+++ b/backend/src/models/MarketListing.js
@@ -8,6 +8,8 @@ const offerSchema = new mongoose.Schema({
     imageUrl: { type: String, required: true },
     rarity: { type: String, required: true },
     mintNumber: { type: Number, required: true },
+    grade: { type: Number, min: 1, max: 10 },
+    slabbed: { type: Boolean, default: false },
     flavorText: { type: String },
     // Optional modifier information for the offered card
     modifier: { type: mongoose.Schema.Types.Mixed, default: null }
@@ -24,6 +26,8 @@ const marketListingSchema = new mongoose.Schema({
     imageUrl: { type: String, required: true },
     rarity: { type: String, required: true },
     mintNumber: { type: Number, required: true },
+    grade: { type: Number, min: 1, max: 10 },
+    slabbed: { type: Boolean, default: false },
     flavorText: { type: String },
     // Include modifier details if present on the card being listed
     modifier: { type: mongoose.Schema.Types.Mixed, default: null }

--- a/backend/src/routes/MarketRoutes.js
+++ b/backend/src/routes/MarketRoutes.js
@@ -18,6 +18,8 @@ router.post('/listings', protect, sensitiveLimiter, async (req, res) => {
             imageUrl: Joi.string().required(),
             rarity: Joi.string().required(),
             mintNumber: Joi.number().integer().min(0).required(),
+            grade: Joi.number().integer().min(1).max(10).optional(),
+            slabbed: Joi.boolean().optional(),
             flavorText: Joi.string().allow('', null),
             // Modifier may be an ObjectId or populated object; allow any value
             modifier: Joi.any().optional()
@@ -174,6 +176,8 @@ router.post('/listings/:id/offers', protect, sensitiveLimiter, async (req, res) 
                     imageUrl: Joi.string().uri().required(),
                     rarity: Joi.string().required(),
                     mintNumber: Joi.number().integer().min(0).required(),
+                    grade: Joi.number().integer().min(1).max(10).optional(),
+                    slabbed: Joi.boolean().optional(),
                     flavorText: Joi.string().allow('', null),
                     // Optional modifier info for each offered card
                     modifier: Joi.any().optional()

--- a/frontend/src/pages/MarketListingDetails.js
+++ b/frontend/src/pages/MarketListingDetails.js
@@ -112,6 +112,8 @@ const MarketListingDetails = () => {
                 imageUrl: card.imageUrl?.startsWith('http') ? card.imageUrl : `${window.location.origin}${card.imageUrl.startsWith('/') ? '' : '/'}${card.imageUrl}`,
                 rarity: card.rarity || (card.rarities && card.rarities[0]?.rarity) || '',
                 mintNumber: card.mintNumber != null ? card.mintNumber : 0,
+                grade: card.grade,
+                slabbed: card.slabbed,
                 flavorText: card.flavorText || ''
             }));
             const res = await fetchWithAuth(`/api/market/listings/${id}/offers`, {


### PR DESCRIPTION
## Summary
- include grade/slabbed fields in `MarketListing` model
- accept grade/slabbed in market routes
- send grade/slabbed when making offers

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd0ace5f08330b0878d5b05305ba5