### PR TITLE
Fix grading page card alignment and button styles

### DIFF
--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -88,8 +88,8 @@
 
 .cancel-btn {
     padding: 0.5rem 1rem;
-    background: var(--surface-darker);
-    color: var(--text-primary);
+    background: var(--brand-primary);
+    color: var(--background-dark);
     border: none;
     border-radius: 8px;
     cursor: pointer;
@@ -97,7 +97,7 @@
 }
 
 .cancel-btn:hover {
-    background: var(--surface-dark);
+    background: var(--brand-secondary);
     transform: scale(1.05);
 }
 
@@ -141,7 +141,9 @@
 /* Grading reveal area */
 .grading-area {
     margin: 2rem 0;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .grading-area h3 {


### PR DESCRIPTION
## Summary
- ensure grading action buttons use same styling
- center selected card without affecting its inner text

## Testing
- `npm test --prefix frontend -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c01f0595c8330bf86ec4eadda19fa