### PR TITLE
Update unique slab text color

### DIFF
--- a/frontend/src/styles/CardComponent.css
+++ b/frontend/src/styles/CardComponent.css
@@ -904,6 +904,12 @@
     white-space: nowrap;
 }
 
+/* White text on slabs for Unique rarity */
+.card-container.unique.slabbed .slab-grade,
+.card-container.unique.slabbed .slab-name {
+    color: white;
+}
+
 @keyframes glitchTop {
     0% { transform: translate(0); }
     20% { transform: translate(-2px, -2px); }


### PR DESCRIPTION
## Summary
- tweak CSS for unique card slabs so slab text is white

## Testing
- `CI=true npm test --silent` in `frontend`
- `npm test --silent` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c09c0eae4833098ead808a20f205b