### PR TITLE
Fix grading page done button and admin override visibility

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { fetchWithAuth, gradeCard, completeGrading, revealGradedCard, fetchUserProfile } from '../utils/api';
 import BaseCard from '../components/BaseCard';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -7,7 +8,9 @@ import { getRarityColor } from '../constants/rarityColors';
 import '../styles/AdminGradingPage.css';
 
 const AdminGradingPage = () => {
+    const navigate = useNavigate();
     const [selectedUser, setSelectedUser] = useState('');
+    const [isAdmin, setIsAdmin] = useState(false);
     const [cards, setCards] = useState([]);
     const [loading, setLoading] = useState(false);
     const [gradingLoading, setGradingLoading] = useState(false);
@@ -25,6 +28,11 @@ const AdminGradingPage = () => {
             try {
                 setLoading(true);
                 const profile = await fetchUserProfile();
+                if (!profile.isAdmin) {
+                    navigate('/');
+                    return;
+                }
+                setIsAdmin(true);
                 setSelectedUser(profile._id);
                 const userData = await fetchWithAuth(`/api/users/${profile._id}/collection`);
                 setCards(userData.cards || []);
@@ -36,7 +44,7 @@ const AdminGradingPage = () => {
             }
         };
         init();
-    }, []);
+    }, [navigate]);
 
 
     const handleSelectCard = (card) => {
@@ -245,7 +253,11 @@ const AdminGradingPage = () => {
                                                 <div className="grading-timeleft-badge">
                                                     {days}d {hours}h {minutes}m {seconds}s
                                                 </div>
-                                                <button onClick={() => handleOverride(card._id)}>Override</button>
+                                                {isAdmin && (
+                                                    <button onClick={() => handleOverride(card._id)}>
+                                                        Override
+                                                    </button>
+                                                )}
                                             </div>
                                         );
                                     })}

--- a/frontend/src/pages/__tests__/AdminGradingPage.test.js
+++ b/frontend/src/pages/__tests__/AdminGradingPage.test.js
@@ -1,4 +1,5 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
+jest.mock('react-router-dom', () => ({ useNavigate: jest.fn() }), { virtual: true });
 import AdminGradingPage from '../AdminGradingPage';
 import { fetchWithAuth, gradeCard, fetchUserProfile } from '../../utils/api';
 
@@ -13,7 +14,7 @@ beforeEach(() => {
   fetchWithAuth.mockReset();
   gradeCard.mockReset();
   fetchUserProfile.mockReset();
-  fetchUserProfile.mockResolvedValue({ _id: '1' });
+  fetchUserProfile.mockResolvedValue({ _id: '1', isAdmin: true });
   fetchWithAuth.mockImplementation((endpoint) => {
     if (endpoint === '/api/users/1/collection') return Promise.resolve({ cards: mockCards });
     return Promise.resolve({});

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -60,7 +60,7 @@
 }
 
 .done-btn {
-    margin-top: 0.5rem;
+    margin-top: 3rem;
 }
 
 .grade-btn {


### PR DESCRIPTION
## Summary
- ensure only admins can access admin grading page and show override button
- move `Done` button lower so it's visible beneath the slab overlay
- adjust tests for new admin check

## Testing
- `npx react-scripts test --runTestsByPath src/pages/__tests__/AdminGradingPage.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687d0ac22ca48330b0670e1d83441716