### PR TITLE
Improve admin grading page styling

### DIFF
--- a/frontend/src/pages/AdminGradingPage.js
+++ b/frontend/src/pages/AdminGradingPage.js
@@ -143,8 +143,12 @@ const AdminGradingPage = () => {
     return (
         <div className="admin-grading-page">
             {gradingLoading && <LoadingSpinner />}
-            <h2>Admin Card Grading</h2>
-
+            <h1>Admin Card Grading</h1>
+            <p className="grading-description">
+                Use the controls below to search a user's collection and select
+                cards for grading. Once a card is graded you can reveal the slab
+                to complete the process.
+            </p>
 
             {selectedUser && (
                 <div className="grading-controls">

--- a/frontend/src/styles/AdminGradingPage.css
+++ b/frontend/src/styles/AdminGradingPage.css
@@ -10,13 +10,39 @@
     flex-direction: column;
 }
 
-.admin-grading-page h2 {
+.admin-grading-page h1 {
     text-align: center;
-    margin-top: 80px;
-    margin-bottom: 40px;
-    font-size: 2.8rem;
-    font-weight: 700;
-    letter-spacing: 1px;
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    font-size: 2.25rem;
+    font-weight: 500;
+    position: relative;
+    color: var(--text-primary);
+}
+
+.admin-grading-page h1::after {
+    content: '';
+    position: absolute;
+    bottom: -0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 2px;
+    background: var(--brand-primary);
+    border-radius: 2px;
+}
+
+.grading-description {
+    text-align: center;
+    font-size: 1.1rem;
+    margin: 0.5rem auto 1.5rem;
+    max-width: 800px;
+    color: var(--text-primary);
+    background: var(--surface-dark);
+    border: 1px solid var(--border-dark);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    line-height: 1.6;
 }
 
 .grading-card-list {


### PR DESCRIPTION
## Summary
- style heading on Admin Grading page like other pages
- add help text describing how grading works

## Testing
- `npm install --silent` *(in frontend)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d1ded97bc83309e088076a830ea3d