### PR TITLE
Allow all users to access card grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Run these commands from the `backend` directory.
 
 Refer to [`backend/README_trading_market.md`](backend/README_trading_market.md) for additional backend documentation.
 
-## Card Grading (Admin Only)
+## Card Grading
 
-Admins can initiate grading for any card from the `/admin/grading` page. Once started, grading takes 24 hours to complete unless an admin overrides the timer. When finished, the card is slabbed with a random grade from 1–10 and displays a plastic "slab" overlay with the grade value.
+Any logged in user can initiate grading for a card from the `/grading` page. Once started, grading takes 24 hours to complete unless an admin overrides the timer. When finished, the card is slabbed with a random grade from 1–10 and displays a plastic "slab" overlay with the grade value.
 

--- a/backend/src/routes/gradingRoutes.js
+++ b/backend/src/routes/gradingRoutes.js
@@ -1,11 +1,11 @@
 const express = require('express');
-const { protect, adminOnly } = require('../middleware/authMiddleware');
+const { protect } = require('../middleware/authMiddleware');
 const { startGrading, completeGrading, revealGradedCard } = require('../controllers/gradingController');
 
 const router = express.Router();
 
-router.post('/grade-card', protect, adminOnly, startGrading);
-router.post('/grade-card/complete', protect, adminOnly, completeGrading);
-router.post('/grade-card/reveal', protect, adminOnly, revealGradedCard);
+router.post('/grade-card', protect, startGrading);
+router.post('/grade-card/complete', protect, completeGrading);
+router.post('/grade-card/reveal', protect, revealGradedCard);
 
 module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ const MarketPage = lazy(() => import('./pages/MarketPage'));
 const CreateListingPage = lazy(() => import('./pages/CreateListingPage'));
 const MarketListingDetails = lazy(() => import('./pages/MarketListingDetails'));
 const AdminActions = lazy(() => import('./pages/AdminActions'));
-const AdminGradingPage = lazy(() => import('./pages/AdminGradingPage'));
+const CardGradingPage = lazy(() => import('./pages/CardGradingPage'));
 const CardEditor = lazy(() => import('./components/CardEditor'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 const AchievementsPage = lazy(() => import('./pages/AchievementsPage'));
@@ -142,8 +142,8 @@ const App = () => {
                         element={user?.isAdmin ? <AdminActions user={user} /> : <Navigate to="/login" />}
                     />
                     <Route
-                        path="/admin/grading"
-                        element={user?.isAdmin ? <AdminGradingPage /> : <Navigate to="/login" />}
+                        path="/grading"
+                        element={user ? <CardGradingPage /> : <Navigate to="/login" />}
                     />
                     <Route path="/catalogue" element={<CataloguePage />} />
                     <Route path="/market" element={<MarketPage />} />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -167,17 +167,17 @@ const Navbar = ({ isAdmin }) => {
                                 Admin Actions
                             </NavLink>
                         </li>
-                        <li>
-                            <NavLink
-                                to="/admin/grading"
-                                className="nav-link"
-                                onClick={() => setMenuOpen(false)}
-                            >
-                                Admin Grading
-                            </NavLink>
-                        </li>
                     </>
                 )}
+                <li>
+                    <NavLink
+                        to="/grading"
+                        className="nav-link"
+                        onClick={() => setMenuOpen(false)}
+                    >
+                        Card Grading
+                    </NavLink>
+                </li>
                 <li>
                     <NavLink
                         to="/market"

--- a/frontend/src/pages/CardGradingPage.js
+++ b/frontend/src/pages/CardGradingPage.js
@@ -5,9 +5,9 @@ import BaseCard from '../components/BaseCard';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { rarities } from '../constants/rarities';
 import { getRarityColor } from '../constants/rarityColors';
-import '../styles/AdminGradingPage.css';
+import '../styles/CardGradingPage.css';
 
-const AdminGradingPage = () => {
+const CardGradingPage = () => {
     const navigate = useNavigate();
     const [selectedUser, setSelectedUser] = useState('');
     const [isAdmin, setIsAdmin] = useState(false);
@@ -28,11 +28,7 @@ const AdminGradingPage = () => {
             try {
                 setLoading(true);
                 const profile = await fetchUserProfile();
-                if (!profile.isAdmin) {
-                    navigate('/');
-                    return;
-                }
-                setIsAdmin(true);
+                setIsAdmin(profile.isAdmin);
                 setSelectedUser(profile._id);
                 const userData = await fetchWithAuth(`/api/users/${profile._id}/collection`);
                 setCards(userData.cards || []);
@@ -141,9 +137,9 @@ const AdminGradingPage = () => {
     const hasSlabbed = cards.some(card => card.slabbed);
 
     return (
-        <div className="admin-grading-page">
+        <div className="card-grading-page">
             {gradingLoading && <LoadingSpinner />}
-            <h1>Admin Card Grading</h1>
+            <h1>Card Grading</h1>
             <p className="grading-description">
                 Use the controls below to search a user's collection and select
                 cards for grading. Once a card is graded you can reveal the slab
@@ -320,4 +316,4 @@ const AdminGradingPage = () => {
     );
 };
 
-export default AdminGradingPage;
+export default CardGradingPage;

--- a/frontend/src/pages/__tests__/CardGradingPage.test.js
+++ b/frontend/src/pages/__tests__/CardGradingPage.test.js
@@ -1,6 +1,6 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
 jest.mock('react-router-dom', () => ({ useNavigate: jest.fn() }), { virtual: true });
-import AdminGradingPage from '../AdminGradingPage';
+import CardGradingPage from '../CardGradingPage';
 import { fetchWithAuth, gradeCard, fetchUserProfile } from '../../utils/api';
 
 jest.mock('../../utils/api');
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 test('filters cards by search and rarity', async () => {
-  const { getByTestId, queryByText } = render(<AdminGradingPage />);
+  const { getByTestId, queryByText } = render(<CardGradingPage />);
   await waitFor(() => getByTestId('search-input'));
 
   fireEvent.change(getByTestId('search-input'), { target: { value: 'Alpha' } });
@@ -46,7 +46,7 @@ test('grading workflow moves card to in-progress list', async () => {
     return Promise.resolve({});
   });
 
-  const { getByTestId } = render(<AdminGradingPage />);
+  const { getByTestId } = render(<CardGradingPage />);
   await waitFor(() => getByTestId('select-btn-c1'));
 
   fireEvent.click(getByTestId('select-btn-c1'));
@@ -59,7 +59,7 @@ test('grading workflow moves card to in-progress list', async () => {
 
 test('cancel deselects the card', async () => {
   fetchWithAuth.mockResolvedValueOnce({ cards: mockCards });
-  const { getByTestId, queryByTestId } = render(<AdminGradingPage />);
+  const { getByTestId, queryByTestId } = render(<CardGradingPage />);
   await waitFor(() => getByTestId('select-btn-c1'));
   fireEvent.click(getByTestId('select-btn-c1'));
   await waitFor(() => getByTestId('selected-card-area'));

--- a/frontend/src/styles/CardGradingPage.css
+++ b/frontend/src/styles/CardGradingPage.css
@@ -1,5 +1,5 @@
-/* Admin Grading Page */
-.admin-grading-page {
+/* Card Grading Page */
+.card-grading-page {
     padding: 40px 20px;
     max-width: 1800px;
     margin: 0 auto;
@@ -10,7 +10,7 @@
     flex-direction: column;
 }
 
-.admin-grading-page h1 {
+.card-grading-page h1 {
     text-align: center;
     margin-top: 4rem;
     margin-bottom: 1rem;
@@ -20,7 +20,7 @@
     color: var(--text-primary);
 }
 
-.admin-grading-page h1::after {
+.card-grading-page h1::after {
     content: '';
     position: absolute;
     bottom: -0.5rem;


### PR DESCRIPTION
## Summary
- rename AdminGradingPage to CardGradingPage
- expose grading route in the app and navbar
- open backend grading endpoints to all authenticated users
- update README with new grading URL

## Testing
- `npm test --silent --color=false`

------
https://chatgpt.com/codex/tasks/task_e_687d24aba39083308c6cb2a48c13363d