### PR TITLE
Fix profile and card route performance

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -7,9 +7,12 @@ const getUserProfile = async (req, res) => {
     const start = process.hrtime();
     try {
         const dbStart = process.hrtime();
-        const user = await User.findById(req.user._id).select(
-            'username email isAdmin packs openedPacks loginCount featuredCards favoriteCard preferredPack cards twitchProfilePic xp level achievements featuredAchievements'
-        ).populate('preferredPack', 'name').lean();
+        const user = await User.findById(req.user._id)
+            .select(
+                'username email isAdmin packs openedPacks loginCount featuredCards favoriteCard preferredPack twitchProfilePic xp level achievements featuredAchievements'
+            )
+            .populate('preferredPack', 'name')
+            .lean();
         const dbEnd = process.hrtime(dbStart);
         console.log(`[PERF] [getUserProfile] DB query took ${dbEnd[0] * 1000 + dbEnd[1] / 1e6} ms`);
         if (!user) {

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -28,9 +28,13 @@ const protect = async (req, res, next) => {
             req.isAdmin = req.user.isAdmin; // Attach admin status
             console.log('[AUTH VALIDATE] User validated:', req.user.username);
 
-            // Update lastActive timestamp on every authenticated request
-            req.user.lastActive = new Date();
-            await req.user.save();
+            // Update lastActive timestamp asynchronously without saving full document
+            User.updateOne(
+                { _id: req.user._id },
+                { $set: { lastActive: new Date() } }
+            ).catch((err) =>
+                console.error('[lastActive update failed]', err)
+            );
 
             next(); // Proceed to the next middleware or route
         } catch (error) {

--- a/backend/src/routes/cardRoutes.js
+++ b/backend/src/routes/cardRoutes.js
@@ -48,7 +48,8 @@ router.get('/', async (req, res) => {
             Card.find(query)
                 .sort(sortOption)
                 .skip(skip)
-                .limit(parseInt(limit)),
+                .limit(parseInt(limit))
+                .lean(),
             Card.countDocuments(query),
         ]);
 
@@ -74,7 +75,8 @@ router.get('/search', async (req, res) => {
     try {
         console.log('Searching for cards with name:', name);
         // Search for cards where the name matches (case-insensitive)
-        const cards = await Card.find({ name: { $regex: name, $options: 'i' } });
+        const cards = await Card.find({ name: { $regex: name, $options: 'i' } })
+            .lean();
         console.log('Search results:', cards);
         res.status(200).json({ cards });
     } catch (err) {
@@ -146,19 +148,6 @@ router.get('/collection', protect, async (req, res) => {
     }
 });
 
-router.get('/search', async (req, res) => {
-    const { name } = req.query;
-    if (!name) {
-        return res.status(400).json({ message: 'Name query parameter is required.' });
-    }
-    try {
-        // Search for cards where the name matches (case-insensitive)
-        const cards = await Card.find({ name: { $regex: name, $options: 'i' } });
-        res.status(200).json({ cards });
-    } catch (err) {
-        res.status(500).json({ message: 'Failed to search cards', error: err.message });
-    }
-});
 
 // Dynamic route for a single card must come last to prevent conflict with /search
 // GET /api/cards/search?name=...


### PR DESCRIPTION
## Summary
- update lastActive asynchronously using updateOne
- slim down fields returned by `getUserProfile`
- use `lean()` in card list and search endpoints
- remove duplicate search route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883452365d08330bcb04f0a01399553