### PR TITLE
Refine validate route user query

### DIFF
--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -122,7 +122,9 @@ router.post("/validate", async (req, res) => {
     try {
         const decoded = jwt.verify(token, process.env.JWT_SECRET);
         // Note: decoded.id is actually the Twitch ID
-        const user = await User.findOne({ twitchId: decoded.id }).select("-password");
+        const user = await User.findOne({ twitchId: decoded.id })
+            .select("username email isAdmin packs loginCount xp level twitchProfilePic")
+            .lean();
         if (!user) {
             return res.status(401).json({ message: "User not found" });
         }


### PR DESCRIPTION
## Summary
- trim down fields returned by `/validate` to keep response light

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688366dacd3483308bd8232ed333d80f