### PR TITLE
Fix auth middleware user ID

### DIFF
--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -24,7 +24,11 @@ const protect = async (req, res, next) => {
             }
 
             // Attach user details to the request for downstream use
-            req.userId = req.user._id.toString();
+            // Assign both `_id` and `id` properties to support plain objects
+            // returned by `.lean()` while maintaining compatibility with
+            // existing controller logic that expects `req.user.id`.
+            req.user.id = req.user._id.toString();
+            req.userId = req.user.id;
             req.username = req.user.username; // Attach username to the request
             req.twitchId = req.user.twitchId; // Attach Twitch ID to the request
             req.isAdmin = req.user.isAdmin; // Attach admin status


### PR DESCRIPTION
## Summary
- ensure `req.user.id` is available after auth by assigning `_id` string

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68836de8224c8330b2704457b8a7c3f2