### PR TITLE
Refactor notifications to their own model

### DIFF
--- a/backend/src/helpers/notificationHelper.js
+++ b/backend/src/helpers/notificationHelper.js
@@ -1,38 +1,23 @@
-const User = require('../models/userModel');
+const Notification = require('../models/notificationModel');
 // Import the specific function needed from notificationService
-const { sendNotificationToUser } = require('../../notificationService'); // Adjust path as needed
+const { sendNotificationToUser } = require('../../notificationService');
 
 const createNotification = async (userId, { type, message, link, extra = {} }) => {
     try {
         console.log('Creating notification for user:', userId, { type, message, link, extra });
 
-        // Prepare the notification object first
-        // Note: MongoDB will automatically add an _id when this is pushed to the array
-        const notificationData = {
+        const notification = await Notification.create({
+            userId,
             type,
             message,
             link,
             isRead: false,
             createdAt: new Date(),
             extra
-        };
+        });
 
-        // Save notification to the database and get the updated user
-        const updatedUser = await User.findByIdAndUpdate(
-            userId,
-            { $push: { notifications: notificationData } },
-            { new: true } // `new: true` returns the modified document
-        ).populate('notifications'); // Populate the notifications array
-
-        if (updatedUser) {
-            // If saving was successful, send the real-time notification via Socket.IO
-            // The new notification is the last one in the array
-            const savedNotification = updatedUser.notifications[updatedUser.notifications.length - 1];
-            sendNotificationToUser(userId, savedNotification); // Send the actual saved notification object
-            console.log('Notification saved and real-time event sent to user:', userId);
-        } else {
-            console.error('Failed to find user to update notification for:', userId);
-        }
+        sendNotificationToUser(userId, notification.toObject());
+        console.log('Notification saved and real-time event sent to user:', userId);
 
     } catch (error) {
         console.error('Error creating notification:', error.message);

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -16,7 +16,10 @@ const protect = async (req, res, next) => {
 
             // Find the user by `twitchId` or `_id` based on the token payload
             req.user = await User.findOne({ twitchId: decoded.id })
-                .select('username twitchId isAdmin')
+                .select(
+                    'username email isAdmin packs openedPacks loginCount featuredCards favoriteCard preferredPack twitchProfilePic xp level achievements featuredAchievements twitchId'
+                )
+                .populate('preferredPack', 'name')
                 .lean();
             if (!req.user) {
                 console.error('[AUTH VALIDATE] User not found for Twitch ID:', decoded.id);

--- a/backend/src/models/notificationModel.js
+++ b/backend/src/models/notificationModel.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const notificationSchema = new mongoose.Schema({
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    type: { type: String, required: true },
+    message: { type: String, required: true },
+    link: { type: String },
+    isRead: { type: Boolean, default: false },
+    createdAt: { type: Date, default: Date.now },
+    extra: { type: Object, default: {} }
+});
+
+const Notification = mongoose.model('Notification', notificationSchema);
+
+module.exports = Notification;

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -12,7 +12,6 @@ const cardSchema = new mongoose.Schema({
         type: String,
         enum: ['available', 'pending', 'escrow'],
         default: 'available',
-        index: true,
     }, // Card status
     grade: { type: Number, min: 1, max: 10 },
     slabbed: { type: Boolean, default: false },
@@ -21,17 +20,7 @@ const cardSchema = new mongoose.Schema({
 });
 
 // Index nested card id for faster $elemMatch queries
-cardSchema.index({ _id: 1 });
-
-// Notification schema
-const notificationSchema = new mongoose.Schema({
-    type: { type: String, required: true },
-    message: { type: String, required: true },
-    link: { type: String }, // Optional URL or route
-    isRead: { type: Boolean, default: false },
-    createdAt: { type: Date, default: Date.now },
-    extra: { type: Object, default: {} } // For any extra flags, e.g., priority
-});
+// Mongoose automatically indexes _id
 
 const userSchema = new mongoose.Schema({
     username: { type: String, required: true, unique: true, index: true },
@@ -57,7 +46,6 @@ const userSchema = new mongoose.Schema({
     },
     // User's preferred pack template for admin openings
     preferredPack: { type: mongoose.Schema.Types.ObjectId, ref: 'Pack', default: null },
-    notifications: [notificationSchema], // NEW: Notifications for the user
     firstLogin: { type: Boolean, default: false },
     isAdmin: { type: Boolean, default: false },
     lastActive: { type: Date }, // Last active in chat
@@ -104,7 +92,6 @@ const userSchema = new mongoose.Schema({
 userSchema.index({ 'cards._id': 1 });
 userSchema.index({ 'cards.status': 1 });
 userSchema.index({ 'cards.name': 1, 'cards.rarity': 1 });
-userSchema.index({ 'notifications.isRead': 1 });
 
 const User = mongoose.model('User', userSchema);
 

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -113,27 +113,6 @@ router.get(
     }
 );
 
-// Validate JWT token route – returns the full user profile.
-router.post("/validate", async (req, res) => {
-    const token = req.headers.authorization?.split(" ")[1];
-    if (!token) {
-        return res.status(401).json({ message: "No token provided" });
-    }
-    try {
-        const decoded = jwt.verify(token, process.env.JWT_SECRET);
-        // Note: decoded.id is actually the Twitch ID
-        const user = await User.findOne({ twitchId: decoded.id })
-            .select("username email isAdmin packs loginCount xp level twitchProfilePic")
-            .lean();
-        if (!user) {
-            return res.status(401).json({ message: "User not found" });
-        }
-        return res.status(200).json(user);
-    } catch (err) {
-        return res.status(401).json({ message: "Invalid token" });
-    }
-});
-
 // Route to check authentication status via passport
 router.get("/user", (req, res) => {
     if (req.isAuthenticated()) {

--- a/backend/src/routes/testNotificationRoutes.js
+++ b/backend/src/routes/testNotificationRoutes.js
@@ -2,8 +2,8 @@
 const express = require('express');
 const router = express.Router();
 const { protect } = require('../middleware/authMiddleware');
-const User = require('../models/userModel');
-const { sendNotification } = require('../../notificationService'); // Updated path to notificationService
+const Notification = require('../models/notificationModel');
+const { sendNotificationToUser } = require('../../notificationService');
 
 // GET /api/test-notification
 // This route creates a test notification for the logged-in user.
@@ -24,15 +24,13 @@ router.get('/', protect, async (req, res) => {
         };
 
         // 1) Insert into DB
-        const user = await User.findById(userId);
-        if (!user) {
-            return res.status(404).json({ message: 'User not found' });
-        }
-        user.notifications.push(sampleNotification);
-        await user.save();
+        await Notification.create({
+            userId,
+            ...sampleNotification,
+        });
 
         // 2) Send real-time notification
-        sendNotification(userId, sampleNotification);
+        sendNotificationToUser(userId, sampleNotification);
 
         // 3) Return a JSON response
         res.json({


### PR DESCRIPTION
## Summary
- denormalize notifications into dedicated collection
- remove old notifications array and indexes from user model
- use Notification model across routes and helpers
- simplify `/api/users/me` to use profile loaded by auth middleware
- drop obsolete auth `/validate` endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688372000f608330afbfbce9686ee4cf