### PR TITLE
Optimize pack opening

### DIFF
--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -57,21 +57,24 @@ const openPack = async (req, res) => {
         }
 
         newCard.acquiredAt = new Date();
-        user.cards.push(newCard);
-        user.openedPacks += 1;
-        user.packs -= 1;
 
-        // Award XP for opening a pack
-        user.xp = (user.xp || 0) + 10;
-        // Level up logic (simple: 100 XP per level)
-        user.level = Math.floor(user.xp / 100) + 1;
+        const xpGain = 10;
+        const newLevel = Math.floor((user.xp + xpGain) / 100) + 1;
 
-        await user.save();
+        const updatedUser = await User.findByIdAndUpdate(
+            userId,
+            {
+                $push: { cards: newCard },
+                $inc: { packs: -1, openedPacks: 1, xp: xpGain },
+                $set: { level: newLevel }
+            },
+            { new: true }
+        );
 
         const { checkAndGrantAchievements } = require('../helpers/achievementHelper');
-        await checkAndGrantAchievements(user);
+        await checkAndGrantAchievements(updatedUser);
 
-        res.status(200).json({ message: 'Pack opened successfully', card: newCard, packs: user.packs });
+        res.status(200).json({ message: 'Pack opened successfully', card: newCard, packs: updatedUser.packs });
     } catch (error) {
         console.error('[openPack] Error:', error.message);
         res.status(500).json({ message: 'Failed to open pack' });
@@ -153,18 +156,21 @@ const openPacksForUser = async (req, res) => {
             newCard.acquiredAt = new Date();
         }
 
-        user.packs -= 1;
-        user.openedPacks += 1;
+        const xpGain = 10;
+        const newLevel = Math.floor((user.xp + xpGain) / 100) + 1;
 
-        // Award XP for admin opening pack
-        user.xp = (user.xp || 0) + 10;
-        user.level = Math.floor(user.xp / 100) + 1;
-
-        user.cards.push(...newCards);
-        await user.save();
+        const updatedUser = await User.findByIdAndUpdate(
+            userId,
+            {
+                $push: { cards: { $each: newCards } },
+                $inc: { packs: -1, openedPacks: 1, xp: xpGain },
+                $set: { level: newLevel }
+            },
+            { new: true }
+        );
 
         const { checkAndGrantAchievements } = require('../helpers/achievementHelper');
-        await checkAndGrantAchievements(user);
+        await checkAndGrantAchievements(updatedUser);
 
         res.status(200).json({ message: 'Pack opened successfully', newCards });
     } catch (error) {

--- a/backend/src/helpers/cardHelpers.js
+++ b/backend/src/helpers/cardHelpers.js
@@ -1,5 +1,4 @@
 const Card = require('../models/cardModel');
-const User = require('../models/userModel'); // Using the User model since cards are embedded
 
 // Updated rarity probabilities: Basic is most common, Divine is most rare.
 const rarityProbabilities = [
@@ -90,18 +89,6 @@ const generateCardWithProbability = async () => {
             // Select a random mint number from availableMintNumbers
             const randomIndex = Math.floor(Math.random() * rarityObj.availableMintNumbers.length);
             const mintNumber = rarityObj.availableMintNumbers[randomIndex];
-
-            // Check that no card with the same name, rarity, and mint number exists in any user's collection
-            const duplicate = await User.findOne({
-                $or: [
-                    { cards: { $elemMatch: { name: selectedCard.name, rarity: selectedRarity, mintNumber } } },
-                    { openedCards: { $elemMatch: { name: selectedCard.name, rarity: selectedRarity, mintNumber } } }
-                ]
-            });
-            if (duplicate) {
-                console.warn(`Duplicate card detected for ${selectedCard.name}, rarity: ${selectedRarity}, mint number: ${mintNumber}. Retrying...`);
-                continue;
-            }
 
             // Atomically update the card: decrement remainingCopies and remove the chosen mint number
             const updatedCard = await Card.findOneAndUpdate(
@@ -225,16 +212,6 @@ const generateCardFromPool = async (poolIds) => {
             const randomIndex = Math.floor(Math.random() * rarityObj.availableMintNumbers.length);
             const mintNumber = rarityObj.availableMintNumbers[randomIndex];
 
-            const duplicate = await User.findOne({
-                $or: [
-                    { cards: { $elemMatch: { name: selectedCard.name, rarity: selectedRarity, mintNumber } } },
-                    { openedCards: { $elemMatch: { name: selectedCard.name, rarity: selectedRarity, mintNumber } } }
-                ]
-            });
-            if (duplicate) {
-                console.warn(`[generateCardFromPool] Duplicate card detected. Retrying...`);
-                continue;
-            }
 
             const updatedCard = await Card.findOneAndUpdate(
                 {


### PR DESCRIPTION
## Summary
- rely on card collection to enforce mint uniqueness
- update user with atomic operations when opening packs

## Testing
- `npm -C backend test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68837ffc78f883309e9d815f9cf7ae1e