### PR TITLE
Add debug pack simulation feature

### DIFF
--- a/backend/src/routes/packRoutes.js
+++ b/backend/src/routes/packRoutes.js
@@ -8,6 +8,7 @@ const {
     getUsersWithPacks,
     getAllPacks,
     openPacksForUser,
+    debugOpenPackForUser,
     openPackById, // Make sure this is defined in packController
 } = require('../controllers/packController');
 
@@ -17,6 +18,7 @@ router.get('/usersWithPacks', protect, adminOnly, getUsersWithPacks); // Admin: 
 router.post('/openpack', protect, openPack); // Open a pack for the authenticated user
 router.get('/allpacks', protect, adminOnly, getAllPacks); // Admin: Fetch all packs
 router.post('/admin/openPacksForUser/:userId', protect, adminOnly, openPacksForUser); // Admin: Open packs for a specific user
+router.post('/admin/debugOpenPack/:userId', protect, adminOnly, debugOpenPackForUser); // Admin: Generate pack without side effects
 router.get('/open/:packId', protect, adminMiddleware, openPackById); // Admin: Open a specific pack by ID
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- support new debug pack generation endpoints
- allow admins to generate debug packs without affecting inventory
- add debug pack button to admin dashboard
- implement pack preview helpers

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(interactive install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68838c2233d48330bb864e9960343b8f