### PR TITLE
Improve /api/packs/mypacks speed

### DIFF
--- a/backend/src/controllers/packController.js
+++ b/backend/src/controllers/packController.js
@@ -238,7 +238,7 @@ const debugOpenPackForUser = async (req, res) => {
 const getMyPacks = async (req, res) => {
     try {
         const userId = req.user.id;
-        const user = await User.findById(userId);
+        const user = await User.findById(userId).select('packs');
         if (!user) {
             return res.status(404).json({ message: 'User not found' });
         }


### PR DESCRIPTION
## Summary
- query only the packs field when fetching packs for the logged in user

## Testing
- `npm test -- --watchAll=false` (frontend)
- `npm test` (backend, expected failure: `Error: no test specified`)


------
https://chatgpt.com/codex/tasks/task_e_6883949c31588330813ba7c4a93f9aa8